### PR TITLE
Change MuID segmentation code in all methods where it was swapped

### DIFF
--- a/Geometry/ChannelMapAlgs/SegmentationMuIDAlg.cxx
+++ b/Geometry/ChannelMapAlgs/SegmentationMuIDAlg.cxx
@@ -180,8 +180,8 @@ namespace gar {
                 double stripLength = 0.;
                 int layer = _decoder->get(cID, "layer");
 
-                if(layer == 1 || layer == 3) stripLength = _layer_dim_X;
-                if(layer == 2) stripLength = _layer_dim_Y;
+                if(layer == 1 || layer == 3) stripLength = _layer_dim_Y;
+                if(layer == 2) stripLength = _layer_dim_X;
 
                 return stripLength;
             }
@@ -195,19 +195,19 @@ namespace gar {
                 TVector3 stripEnd2(0., 0., 0.);
 
                 if(layer == 1 || layer == 3) {
-                    stripEnd1.SetX(-_layer_dim_X/2.);
-                    stripEnd2.SetX(_layer_dim_X/2.);
-                    stripEnd1.SetY(local[1]);
-                    stripEnd2.SetY(local[1]);
+                    stripEnd1.SetY(-_layer_dim_Y/2.);
+                    stripEnd2.SetY(_layer_dim_Y/2.);
+                    stripEnd1.SetX(local[0]);
+                    stripEnd2.SetX(local[0]);
                     stripEnd1.SetZ(local[2]);
                     stripEnd2.SetZ(local[2]);
                 }
 
                 if(layer == 2) {
-                    stripEnd1.SetY(-_layer_dim_Y/2.);
-                    stripEnd2.SetY(_layer_dim_Y/2.);
-                    stripEnd1.SetX(local[0]);
-                    stripEnd2.SetX(local[0]);
+                    stripEnd1.SetX(-_layer_dim_X/2.);
+                    stripEnd2.SetX(_layer_dim_X/2.);
+                    stripEnd1.SetY(local[1]);
+                    stripEnd2.SetY(local[1]);
                     stripEnd1.SetZ(local[2]);
                     stripEnd2.SetZ(local[2]);
                 }
@@ -229,13 +229,13 @@ namespace gar {
                 int layer = _decoder->get(cID, "layer");
 
                 if(layer == 1 || layer == 3) {
-                    time1 = ( _layer_dim_X / 2 + local[0] ) / c;
-                    time2 = ( _layer_dim_X / 2 - local[0] ) / c;
+                    time1 = ( _layer_dim_Y / 2 + local[1] ) / c;
+                    time2 = ( _layer_dim_Y / 2 - local[1] ) / c;
                 }
 
                 if(layer == 2) {
-                    time1 = ( _layer_dim_Y / 2 + local[1] ) / c;
-                    time2 = ( _layer_dim_Y / 2 - local[1] ) / c;
+                    time1 = ( _layer_dim_X / 2 + local[0] ) / c;
+                    time2 = ( _layer_dim_X / 2 - local[0] ) / c;
                 }
 
                 return std::make_pair(time1, time2);
@@ -255,11 +255,11 @@ namespace gar {
                 if( std::abs(pos) > stripLength / 2. ) pos = (pos > 0) ? stripLength / 2. : -stripLength / 2.;
 
                 if(layer == 1 || layer == 3) {
-                    newlocal = {pos, local[1], local[2]};
+                    newlocal = {local[0], pos, local[2]};
                 }
 
                 if(layer == 2) {
-                    newlocal = {local[0], pos, local[2]};
+                    newlocal = {pos, local[1], local[2]};
                 }
 
                 return newlocal;


### PR DESCRIPTION
As I mentioned at the end of:

https://indico.fnal.gov/event/60550/contributions/271414/attachments/168773/226213/ndgar_11.07.23_caf_pid_update.pdf

there was a small bug affecting the position of the MuID reco hits. That could be seen when computing the distance between a reco hit and the corresponding sim hit (matched using the CellID).

I think the problem was that the order of the segmentation direction in the MuID strips was interchanged in some methods. It looks like after changing that the distance distributions start looking fine. 2D distributions (layer no vs distance) with the before and after can be found in slide 12.

![dist_sim_reco_muid_hits_after](https://github.com/DUNE/garsoft/assets/73996651/6db5b860-4da3-4e98-94a9-c5aa243b6670)
