### PR TITLE
Feature/fix vertex

### DIFF
--- a/Reco/recojob_tpctrackfit2.fcl
+++ b/Reco/recojob_tpctrackfit2.fcl
@@ -18,7 +18,7 @@
 #include "tpcpatrec2.fcl"
 #include "tpctrackfit2.fcl"
 #include "tpccathodestitch.fcl"
-#include "vertexfinder1.fcl"
+#include "vertexfinder1_tpctrackfit2.fcl"
 #include "veefinder1.fcl"
 #include "SiPMHitFinder.fcl"
 #include "CaloClustering.fcl"

--- a/Reco/vertexfinder1.fcl
+++ b/Reco/vertexfinder1.fcl
@@ -9,6 +9,7 @@ standard_vertexfinder1:
  RCut:                   20.0  # in cm -- track endpoints must be this close before assigning them to a common vertex
  DCut:                   3.0   # in cm -- doca of track to best-fit vertex
  NTPCClusCut:            40    # cut on number of TPC Clusters for a track to contribute to finding a vertex at this stage
+ EndsToCheck:            1     # for the new algorithm, only the start needs to be checked          
 }
 
 END_PROLOG

--- a/Reco/vertexfinder1_module.cc
+++ b/Reco/vertexfinder1_module.cc
@@ -50,6 +50,7 @@ namespace gar {
       float fDCut;
       std::string fTrackLabel;
       int fNTPCClusCut;
+      int fEndsToCheck;
 
       // Stub to check that the track is vertexable
       bool goodTrack(TrackPar trk, TrackEnd usebeg);
@@ -65,6 +66,7 @@ namespace gar {
       fDCut = p.get<float>("DCut", 2.0); // doca must be smaller than this in cm
       fNTPCClusCut = p.get<int>("NTPCClusCut",20);  // dimensionless
       fPrintLevel = p.get<int>("PrintLevel",0);
+      fEndsToCheck = p.get<int>("EndsToCheck",2);
 
       art::InputTag trackTag(fTrackLabel);
       consumes< std::vector<rec::Track> >(trackTag);
@@ -99,7 +101,7 @@ namespace gar {
         for (size_t iTrack=0; iTrack<nTrack-1; ++iTrack) {
           TrackPar thisTrack = tracks.at(iTrack);
           // Build that vector for each of the 2 ends of the track
-          for (int fin=0; fin<2; ++fin) {
+          for (int fin=0; fin<fEndsToCheck; ++fin) {
             trackParEnds.clear();
             TrackEnd thisTrackEnd(fin == 0 ? 1 : 0);
             if (! goodTrack(thisTrack,thisTrackEnd)) continue;
@@ -119,7 +121,7 @@ namespace gar {
             // Loop over other trackends to see what is close
             for (size_t jTrack=iTrack+1; jTrack<nTrack; ++jTrack) {
               TrackPar thatTrack = tracks.at(jTrack);
-              for (int fin2=0; fin2<2; ++fin2)
+              for (int fin2=0; fin2<fEndsToCheck; ++fin2)
                 {
                   TrackEnd thatTrackEnd(fin2 == 0 ? 1 : 0);
                   if (thatTrackEnd == TrackEndBeg && usedflag_beg.at(jTrack) != 0) continue;

--- a/Reco/vertexfinder1_module.cc
+++ b/Reco/vertexfinder1_module.cc
@@ -197,8 +197,23 @@ namespace gar {
 
                 // Save vertex & its tracks into vectors that will be written 
                 // to event.
+                
+                size_t IDcheck = 0;
+                size_t nIDs = 0;
+
+                for (size_t i=0; i<trackParEnds.size(); ++i) {
+                  //TrackEnd endInVertex = std::get<1>(trackParEnds[i]);
+                  auto const trackpointer = trackPtrMaker( std::get<2>(trackParEnds[i]) );
+                  if(IDcheck!=trackpointer->getIDNumber()){
+                    IDcheck = trackpointer->getIDNumber();
+                    nIDs++;
+                  }
+                }
+                if(nIDs<=1) continue;
+
                 vtxCol->emplace_back(xyz.data(),cmv,time);
                 auto const vtxpointer = vtxPtrMaker(vtxCol->size()-1);
+               
                 for (size_t i=0; i<trackParEnds.size(); ++i) {
                   TrackEnd endInVertex = std::get<1>(trackParEnds[i]);
                   auto const trackpointer = trackPtrMaker( std::get<2>(trackParEnds[i]) );
@@ -209,6 +224,12 @@ namespace gar {
           } // end loop on 2 ends of iTrack
         } // end loop on iTrack
       }  // End test for nTrack>=2; might put empty vertex list & Assns into event
+      for(size_t i = 0; i<trkVtxAssns->size(); i++){
+        //auto Track = std::get<0>(trkVtxAssns->at(i));
+        //auto Track = std::get<0>(trkVtxAssns->at(i));  
+        //std::cout<<"Track ID Number: "<<Track->getIDNumber()<<"\n ";
+        //std::cout<<"Trk ID Number: "<<Track->getIDNumber()<<" \n ";
+      }
       e.put(std::move(vtxCol));
       e.put(std::move(trkVtxAssns));
     } // end produce method.


### PR DESCRIPTION

![Zvertex_old](https://github.com/DUNE/garsoft/assets/39513048/a07d0325-9e5e-4966-9bc3-01c9d2ed814a)
![zVertex_new](https://github.com/DUNE/garsoft/assets/39513048/330ee50b-8228-4c7b-9b62-32f9aab9ce26)
![xvertex_old](https://github.com/DUNE/garsoft/assets/39513048/6c15ab2f-b8b8-40ab-9660-4f46c0d78caf)
![Xvertex_new](https://github.com/DUNE/garsoft/assets/39513048/391111ff-ae91-4283-ad27-eb97ea32146f)
![Yvertex_old](https://github.com/DUNE/garsoft/assets/39513048/8bd63323-4167-4ddb-86b2-e8c4e8edc5e1)
![YVertex_new](https://github.com/DUNE/garsoft/assets/39513048/141f0b9a-9b77-48cd-89f1-7c30b2c2cf23)
Fixed issue with false vertexes produced by double counting different reconstruction hypotheses of a single track. Now if a vertex has assigned to it only tracks with the same trackID, it is not saved. Additionally, with the new reconstruction producing two different sorting hypotheses, only the starts of tracks need to be checked for vertexing: created a new fcl parameter to handle this difference. Also created an fcl file for retro compatibility.

Note: new KF reconstruction improves vertex reconstruction resolution (see plots)