### PR TITLE
Fix BackTracker edep-sim problem

### DIFF
--- a/MCCheater/BackTracker.fcl
+++ b/MCCheater/BackTracker.fcl
@@ -5,6 +5,44 @@ standard_backtracker:
  DisableRebuild:            false            # switches off Backtracker functionality
 
  G4ModuleLabel:            "geant"           # module that produced the sim::Particle and sim::SimChannel objects
+ G4FirstID:                 0                # first value assigned to MCParticle::TrackId()
+
+ RawTPCDataLabel:          "daq"             # module that made the RawDigits for the TPC
+
+ RawECALDataLabel:         "daqsipm"         # module that made the CaloRawDigits for the ECAL
+ RawECALDataInstance:      "ECAL"            # instance name for the raw hits of the ECAL
+ RawMuIDDataLabel:         "daqsipmmuid"     # module that made the CaloRawDigits for the MuID
+ RawMuIDDataInstance:      "MuID"            # instance name for the raw hits of the MuID
+ ECALtimeResolution:        2.6              # time resolution for hits in ECAL, nsec. (~5 sigma)
+ MinHitEnergyFraction:      0.1              # min frac of total E a G4 track contributes to a TPC hit to be counted
+ MinCaloHitEnergyFrac:      0.1              # min frac of total E a G4 track contributes to a CaloHit to be counted
+
+ TrackLabel:               "track"           # module that produced the TPC tracks
+ TPCClusterLabel:          "tpccluster"      # module that produced the TPCClusters - the stitcher as it happens.
+ TrackFracMCP:              0.8              # Fraction of track's ionization to be tagged as from given MCParticle
+
+ ECALClusterLabel:         "calocluster"     # module that produced the ECAL clusters
+ ClusterECALInstance:      "ECAL"            # instance name for the the ECAL clusters
+ MuIDClusterLabel:         "caloclustermuid" # module that produced the MuID clusters
+ ClusterMuIDInstance:      "MuID"            # instance name for the the MuID clusters
+ ClusterFracMCP:            0.8              # Fraction of ECAL or MuID cluster's ionization to be tagged as from given MCParticle
+
+ SplitEDeps:                true             # use weights from the Pad Response Functions to break true energy deposits
+                                             # in the TPC into channel specific contributions
+
+ DontChaseNeutrons:         true             # Objects in ECAL and MuID are often matched to shower particles;
+                                             # by default, BackTrackerCore::FindTPCEve chases up the tree until
+                                             # it finds an MCParticle which originates in the GArTPC.  With
+                                             # DontChaseNeutrons == true (which is default) it will also stop
+                                             # chasing up the particle tree if it finds a neutron.
+}
+
+standard_backtracker_edep:
+{
+ DisableRebuild:            false            # switches off Backtracker functionality
+
+ G4ModuleLabel:            "edepconvert"     # module that produced the sim::Particle and sim::SimChannel objects
+ G4FirstID:                 -1               # first value assigned to MCParticle::TrackId()
 
  RawTPCDataLabel:          "daq"             # module that made the RawDigits for the TPC
 

--- a/MCCheater/BackTrackerCore.cxx
+++ b/MCCheater/BackTrackerCore.cxx
@@ -35,6 +35,7 @@ namespace gar{
             fDisableRebuild           = pset.get<bool       >("DisableRebuild",       false);
 
             fG4ModuleLabel            = pset.get<std::string>("G4ModuleLabel",       "geant");
+            fG4FirstID                = pset.get<int        >("G4FirstID",            0);
 
             fRawTPCDataLabel          = pset.get<std::string>("RawTPCDataLabel",     "daq");
 
@@ -147,9 +148,9 @@ namespace gar{
 
                 // Walk up the ParticleList not the event store so someday somebody can
                 // change the ParticleList and this will still work.
-                 int mommaTID = fParticleList[walker->TrackId()]->Mother();
-                 // Stop at top of tree!
-                if (mommaTID == 0) break;
+                int mommaTID = fParticleList[walker->TrackId()]->Mother();
+                // Stop at top of tree!
+                if (mommaTID == fG4FirstID) break; // 0 for standard geant, -1 for edep-sim
 
                 walker = TrackIDToParticle(mommaTID);
             }
@@ -201,8 +202,8 @@ namespace gar{
                 // Walk up the ParticleList not the event store so someday somebody can
                 // change the ParticleList and this will still work.
                 int mommaTID = fParticleList[walker->TrackId()]->Mother();
-                 // Stop at top of tree!
-                if (mommaTID == 0) break;
+                // Stop at top of tree!
+                if (mommaTID == fG4FirstID) break; // 0 for standard geant, -1 for edep-sim
 
                 walker = TrackIDToParticle(mommaTID);
             }
@@ -228,7 +229,7 @@ namespace gar{
                 // Walk up the ParticleList not the event store so someday somebody can
                 // change the ParticleList and this will still work.
                 int momma = fParticleList[walker]->Mother();
-                if (momma == 0 || momma == -1) {        // -1 convention for edep-sim
+                if (momma == fG4FirstID) {    // 0 for standard geant, -1 for edep-sim
                     return false;
                 } else {
                     walker = momma;

--- a/MCCheater/BackTrackerCore.h
+++ b/MCCheater/BackTrackerCore.h
@@ -289,6 +289,7 @@ namespace gar{
 
             bool                                                fDisableRebuild;        ///< for switching off backtracker's rebuild of the MCParticle tables
             std::string                                         fG4ModuleLabel;         ///< label for geant4 module
+            int                                                 fG4FirstID;             ///< first value given to MCParticle::TrackId()
             std::string                                         fRawTPCDataLabel;       ///< label for TPC readout module
             std::string                                         fRawECALDataLabel;      ///< label for ECAL readout module
             std::string                                         fRawECALDataInstance;   ///< instance name for the ECAL raw hits


### PR DESCRIPTION
Some time ago we noticed that edep-sim likes to assign MCParticleIDs starting from 0 instead of 1, which is the standard behaviour of our Geant. That affects some of the BackTracker module methods, as the way they check whether they've reached the top of the MC ParticleList is by checking the MCParticleID of the mother particle. In the standard case a mother ID of 0 means you've made it to the top, but for edep-sim that number would be -1.

I thought that doing it like [this](https://github.com/DUNE/garsoft/blob/c4d636af1acdb4e05f936974df4e71442c83979d/MCCheater/BackTrackerCore.cxx#L232) may be problematic when using edep-sim, as there will be cases where `momma == 0` is fine and the loop shouldn't stop there.

I've tried to tackle this issue once and for all by introducing a variable called fG4FirstID in the BackTrackerCore. Its value is set in the .fcl file and it can either be 0 (standard) or -1 (edep-sim). I have also created a copy of the standard_backtracker table called standard_backtracker_edep, with the defaults G4ModuleLabel: "edepconvert" and G4FirstID: -1. It'll be just a matter of using the latter in any .fcl used for edep-sim events.