### PR TITLE
Legacy trackfit2 vertex finder

### DIFF
--- a/Reco/recojob_toad.fcl
+++ b/Reco/recojob_toad.fcl
@@ -67,10 +67,10 @@ tpcclusterpass1:    @local::standard_TPCHitCluster
 vechit:             @local::standard_tpcvechitfinder2
 patrec:             @local::standard_tpcpatrec2
 trackpass1:         @local::standard_tpctrackfit2
-vertexpass1:        @local::standard_vertexfinder1
+vertexpass1:        @local::old_vertexfinder1
 tpccluster:         @local::standard_tpccathodestitch  # use unusual name to keep backward compatibility as this module produces tpc clusters
 track:              @local::standard_tpctrackfit2
-vertex:             @local::standard_vertexfinder1
+vertex:             @local::old_vertexfinder1
 veefinder1:         @local::standard_veefinder1
 sipmhit:            @local::standard_SiPMHitFinder
 sipmhitmuid:        @local::standard_SiPMHitFinder_MuID

--- a/Reco/recojob_tpctrackfit2.fcl
+++ b/Reco/recojob_tpctrackfit2.fcl
@@ -18,7 +18,7 @@
 #include "tpcpatrec2.fcl"
 #include "tpctrackfit2.fcl"
 #include "tpccathodestitch.fcl"
-#include "vertexfinder1_tpctrackfit2.fcl"
+#include "vertexfinder1.fcl"
 #include "veefinder1.fcl"
 #include "SiPMHitFinder.fcl"
 #include "CaloClustering.fcl"
@@ -67,10 +67,10 @@ tpcclusterpass1:    @local::standard_TPCHitCluster
 vechit:             @local::standard_tpcvechitfinder2
 patrec:             @local::standard_tpcpatrec2
 trackpass1:         @local::standard_tpctrackfit2
-vertexpass1:        @local::standard_vertexfinder1
+vertexpass1:        @local::old_vertexfinder1
 tpccluster:         @local::standard_tpccathodestitch  # use unusual name to keep backward compatibility as this module produces tpc clusters
 track:              @local::standard_tpctrackfit2
-vertex:             @local::standard_vertexfinder1
+vertex:             @local::old_vertexfinder1
 veefinder1:         @local::standard_veefinder1
 sipmhit:            @local::standard_SiPMHitFinder
 sipmhitmuid:        @local::standard_SiPMHitFinder_MuID

--- a/Reco/vertexfinder1.fcl
+++ b/Reco/vertexfinder1.fcl
@@ -12,4 +12,16 @@ standard_vertexfinder1:
  EndsToCheck:            1     # for the new algorithm, only the start needs to be checked          
 }
 
+old_vertexfinder1:
+{
+ module_type:            vertexfinder1
+ TrackLabel:             "trackpass1"
+ ChisquaredPerDOFCut:    10.0   # chisquared per degree of freedom requirement
+ PrintLevel:             0     # 0: quiet, 1: more print, 2: print everything
+ RCut:                   20.0  # in cm -- track endpoints must be this close before assigning them to a common vertex
+ DCut:                   3.0   # in cm -- doca of track to best-fit vertex
+ NTPCClusCut:            40    # cut on number of TPC Clusters for a track to contribute to finding a vertex at this stage
+ EndsToCheck:            2     # for the new algorithm, only the start needs to be checked          
+}
+
 END_PROLOG


### PR DESCRIPTION
Small bug in `recojob_tpctrackfit2.fcl`, tried to [include](https://github.com/DUNE/garsoft/blob/c4d636af1acdb4e05f936974df4e71442c83979d/Reco/recojob_tpctrackfit2.fcl#L21) non-existent `vertexfinder1_tpctrackfit2.fcl` file.

I added a new table in `vertexfinder1.fcl` called `old_vertexfinder1`, with `EndsToCheck: 2` as I believe for the tpctrackfit2 algorithm we still need to check the two track ends. It is then used in the two fcls that still use tpctrackfit2.