### PR TITLE
TOAD Input3 Source and associated HDF5 utilities from DUNE-DAQ v4.4.0

### DIFF
--- a/Prototypes/TOAD/RawDecoding/CMakeLists.txt
+++ b/Prototypes/TOAD/RawDecoding/CMakeLists.txt
@@ -5,7 +5,15 @@ simple_plugin(TOADInput "source"
   art::Framework_Services_Registry
 )
 
+simple_plugin(TOADInput3 "source"
+  RawDataProducts
+  Prototypes_TOAD_ChannelMap_TOADChannelMapService_service
+  garsoft::dunedaqhdf5utils3
+  art::Framework_Services_Registry
+)
+
 add_subdirectory(dunedaqhdf5utils2)
+add_subdirectory(dunedaqhdf5utils3)
 install_headers()
 install_fhicl()
 install_source()

--- a/Prototypes/TOAD/RawDecoding/TOADInput3.fcl
+++ b/Prototypes/TOAD/RawDecoding/TOADInput3.fcl
@@ -1,0 +1,16 @@
+BEGIN_PROLOG
+
+TOADRawInput3SourceDefaults :
+{
+  raw_data_label:        "daq"           # module label for products put in the event
+  module_type:           TOADInput3      # source plug-in name
+  ClockFrequencyMHz:     62.5            # clock frequency for converting timestamps
+  HandleSequenceOption:  "ignore"        # What to do about multiple sequence IDs
+                                         #   ignore -- just read them in
+                                         #   increment -- renumber events sequentiall
+					 #   shiftadd -- trignum*TrNscale + sequence ID
+  TrnScale:              10000           # if doing shiftadd, the number to scale the trigger id
+  LogLevel: 0                            # debug printout
+}
+
+END_PROLOG

--- a/Prototypes/TOAD/RawDecoding/TOADInput3.h
+++ b/Prototypes/TOAD/RawDecoding/TOADInput3.h
@@ -1,0 +1,59 @@
+// Input source for the second HDF5 file format version from the DAQ people
+// using the DUNE-DAQ HDF5RawInputFile class
+
+#ifndef TOADInput3_h
+#define TOADInput3_h
+#include "art/Framework/Core/InputSourceMacros.h" 
+#include "art/Framework/IO/Sources/Source.h" 
+#include "art/Framework/IO/Sources/SourceTraits.h"
+#include "art/Framework/Core/fwd.h"
+#include "art/Framework/Core/FileBlock.h"
+#include "art/Framework/Core/ProductRegistryHelper.h"
+#include "art/Framework/IO/Sources/SourceHelper.h"
+#include "art/Framework/IO/Sources/put_product_in_principal.h"
+#include "art/Framework/Principal/EventPrincipal.h"
+#include "art/Framework/Principal/RunPrincipal.h"
+#include "art/Framework/Principal/SubRunPrincipal.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "canvas/Persistency/Provenance/FileFormatVersion.h"
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "fhiclcpp/ParameterSet.h"
+#include "art/Framework/Services/Registry/ServiceHandle.h"
+#include "dunedaqhdf5utils3/HDF5RawDataFile.hpp"
+
+namespace gar {
+//Forward declare the class
+class TOADInput3Detail;
+}
+
+class gar::TOADInput3Detail {
+ public:
+  TOADInput3Detail(fhicl::ParameterSet const & ps,
+                              art::ProductRegistryHelper & rh,
+                              art::SourceHelper const & sh);
+
+  void readFile(std::string const & filename, art::FileBlock*& fb);
+
+  bool readNext(art::RunPrincipal const* const inR,
+                art::SubRunPrincipal const* const inSR,
+                art::RunPrincipal*& outR,
+                art::SubRunPrincipal*& outSR,
+                art::EventPrincipal*& outE);
+
+  void closeCurrentFile() {
+    fRawDataFilePtr.reset();
+  };
+
+ private:
+  dunedaq::hdf5libs::HDF5RawDataFile::record_id_set fUnprocessedEventRecordIDs;
+  std::string pretend_module_name;
+  int fLogLevel;
+  double fClockFreqMHz;               // clock frequency in MHz -- used to unpack trigger timestamps for the event
+  std::string fHandleSequenceOption;  // to steer what to do with trigger record sequence numbers
+  unsigned int fTrnScale;             // in case we are doing shiftadd, this the scale factor on trig number
+  art::SourceHelper const& pmaker;
+
+  std::unique_ptr<dunedaq::hdf5libs::HDF5RawDataFile> fRawDataFilePtr;
+  int fLastEvent;
+ };
+#endif

--- a/Prototypes/TOAD/RawDecoding/TOADInput3_source.cc
+++ b/Prototypes/TOAD/RawDecoding/TOADInput3_source.cc
@@ -1,0 +1,298 @@
+#include "art/Framework/Core/InputSourceMacros.h"
+#include "art/Framework/IO/Sources/Source.h"
+#include "art/Framework/IO/Sources/SourceTraits.h"
+#include "TOADInput3.h"
+#include "RawDataProducts/RawDigit.h"
+#include "TOADFrameOverlay.hpp"
+#include "Prototypes/TOAD/ChannelMap/TOADChannelMapService.h"
+
+// maybe make our own timestamp data product if need be.
+// #include "lardataobj/RawData/RDTimeStamp.h"
+
+gar::TOADInput3Detail::TOADInput3Detail(
+				      fhicl::ParameterSet const & ps,
+				      art::ProductRegistryHelper & rh,
+				      art::SourceHelper const & sh) 
+  : pretend_module_name(ps.get<std::string>("raw_data_label", "daq")),
+    fLogLevel(ps.get<int>("LogLevel", 0)),
+    fClockFreqMHz(ps.get<double>("ClockFrequencyMHz", 50.0)),
+    fHandleSequenceOption(ps.get<std::string>("HandleSequenceOption","ignore")),
+    fTrnScale(ps.get<unsigned int>("TrnScale",10000)),
+    pmaker(sh) {
+    rh.reconstitutes<std::vector<gar::raw::RawDigit>, art::InEvent>(pretend_module_name);
+		   // don't link to lardataobj just to get a RDTimeStamp definition.  If we need one, maybe make a GAr one
+		   // rh.reconstitutes<raw::RDTimeStamp, art::InEvent>(pretend_module_name, "trigger");
+}
+
+  void gar::TOADInput3Detail::readFile(
+				      std::string const & filename, art::FileBlock*& fb) {
+
+    // open the input file with the dunedaq class
+
+    fRawDataFilePtr = std::make_unique<dunedaq::hdf5libs::HDF5RawDataFile>(filename);
+
+    fUnprocessedEventRecordIDs = fRawDataFilePtr->get_all_trigger_record_ids();
+    fLastEvent = 0;
+
+    uint32_t run_number = fRawDataFilePtr->get_attribute<uint32_t>("run_number");
+    MF_LOG_INFO("HDF5")
+      << "HDF5 opened HDF file with run number " <<
+      run_number  << " and " <<
+      fUnprocessedEventRecordIDs.size() << " events";
+    if (fLogLevel > 0)
+      {
+	for (const auto & e : fUnprocessedEventRecordIDs) MF_LOG_INFO("HDF5") << e.first << " " << e.second;
+      }
+
+    fb = new art::FileBlock(art::FileFormatVersion(1, "RawEvent2011"),
+			    filename); 
+  }
+
+bool gar::TOADInput3Detail::readNext(art::RunPrincipal const* const inR,
+				    art::SubRunPrincipal const* const inSR,
+				    art::RunPrincipal*& outR,
+				    art::SubRunPrincipal*& outSR,
+				    art::EventPrincipal*& outE) 
+{
+  
+  // Establish default 'results'
+  outR = 0;
+  outSR = 0;
+  outE = 0;
+
+  if (fUnprocessedEventRecordIDs.empty()) {return false;}
+
+  // take the first unprocessed event off the set
+  //MF_LOG_INFO("HDF5") << "Here 1";
+  auto nextEventRecordID_i = fUnprocessedEventRecordIDs.cbegin();
+  auto nextEventRecordID = *nextEventRecordID_i;
+  fUnprocessedEventRecordIDs.erase(nextEventRecordID_i);
+  //MF_LOG_INFO("HDF5") << "Here 2";
+ 
+  uint32_t run_id = fRawDataFilePtr->get_attribute<uint32_t>("run_number");
+
+  // get trigger record header pointer
+
+  auto trh = fRawDataFilePtr->get_trh_ptr(nextEventRecordID);
+
+  //check that the run number in the trigger record header agrees with that in the file attribute
+  //MF_LOG_INFO("HDF5") << "Here 3";
+
+  auto run_id2 = trh->get_run_number();
+  if (run_id != run_id2)
+    {
+      throw cet::exception("TOADInput3_source.cc") << " Inconsistent run IDs in file attribute and trigger record header " << run_id << " " << run_id2;
+    }
+
+  // check that the trigger record number in the header agrees with what we are expecting
+
+  auto trhtn = trh->get_trigger_number();
+  if (nextEventRecordID.first != trhtn)
+    {
+      throw cet::exception("TOADInput3_source.cc") << " Inconsistent trigger record numbers: " << nextEventRecordID.first << " " << trhtn;
+    }
+  
+  // trigTimeStamp is NOT time but Clock-tick since the epoch.
+  //MF_LOG_INFO("HDF5") << "Here 4";
+
+  uint64_t trigTimeStamp = trh->get_trigger_timestamp();
+  if (fLogLevel > 0)
+    {
+      std::cout << "TOADInput3_source: Trigger Time Stamp: " << trigTimeStamp << std::endl;
+    }
+
+  // this reformats the timestamp -- figure out what you need for TOAD
+  // uint64_t getTrigTime = formatTrigTimeStampWithFrequency(trigTimeStamp, fClockFreqMHz);
+  // currently just a straight copy
+  uint64_t getTrigTime = trigTimeStamp;
+  if (fLogLevel > 0)
+    {
+      std::cout << "TOADInput3_source: getTrigTime: " << getTrigTime << std::endl;
+    }
+  //MF_LOG_INFO("HDF5") << "Here 5";
+
+  art::Timestamp artTrigStamp (getTrigTime);
+  if (fLogLevel > 0)
+    {
+      std::cout << "TOADInput3_source: artTrigStamp: " <<   artTrigStamp.value()<< std::endl;
+    }
+
+  //std::unique_ptr<raw::RDTimeStamp> rd_timestamp(
+  //                                               new raw::RDTimeStamp(trigTimeStamp));
+
+  // make new run if inR is 0 or if the run has changed
+  if (inR == 0 || inR->run() != run_id) {
+    outR = pmaker.makeRunPrincipal(run_id,artTrigStamp);
+  }
+
+  // make new subrun if inSR is 0 or if the subrun has changed
+  art::SubRunID subrun_check(run_id, 1);
+  if (inSR == 0 || subrun_check != inSR->subRunID()) {
+    outSR = pmaker.makeSubRunPrincipal(run_id, 1, artTrigStamp);
+  }
+
+  // this is the trigger record ID:
+  //MF_LOG_INFO("HDF5") << "Here 6";
+
+  int event = nextEventRecordID.first;
+  int sequenceno = nextEventRecordID.second;
+  if ( fHandleSequenceOption == "increment" )
+    {
+      event = fLastEvent + 1;
+      if (fLogLevel > 0)
+	{
+	  std::cout << "TOADInput3_source: assigning event number via incrment: " << event << " orig: " << nextEventRecordID.first << " " << nextEventRecordID.second;
+	}
+    }
+  else if ( fHandleSequenceOption == "shiftadd" )
+    {
+      event = event*fTrnScale + sequenceno;
+	if (fLogLevel > 0)
+	{
+	  std::cout << "TOADInput3_source: assigning event number via shfitadd: " << event << " orig: " << nextEventRecordID.first << " " << nextEventRecordID.second;
+	}
+    }
+  else if ( fHandleSequenceOption == "ignore" )
+    {
+      if (fLogLevel > 0)
+	{
+	  std::cout << "TOADInput3_source: assigning event number ignoring seqID: " << event << " orig: " << nextEventRecordID.first << " " << nextEventRecordID.second;
+	}
+    }
+  else
+    {
+      throw cet::exception("TOADInput3_source.cc") << "Ununderstood HandleSequenceOption: " << fHandleSequenceOption << " use: ignore, increment or shiftadd";
+    }
+  fLastEvent = event;
+
+  outE = pmaker.makeEventPrincipal(run_id, 1, event, artTrigStamp);
+  if (fLogLevel > 0)
+    {
+      std::cout << "TOADInput3_source: Event Time Stamp :" << outE->time().value() << std::endl;
+    }
+
+  //MF_LOG_INFO("HDF5") << "Here 7";
+
+  std::unique_ptr<std::vector<gar::raw::RawDigit>> rdcol = std::make_unique<std::vector<gar::raw::RawDigit>>();
+  //MF_LOG_INFO("HDF5") << "Here 8";
+
+  // put code here to unpack the data and put it in rdcol.
+  // see the example at duneprototypes/Protodune/hd/RawDecoding/PDHDDataInterfaceWIB3_tool.cc in the method getFragmentsForEvent
+  // instead of retrieving the raw file pointer from a service, it's fRawDataFilePtr as a private member of this class
+  // use it instead of rf
+  
+  art::ServiceHandle<dune::TOADChannelMapService> channelMap;
+  dunedaq::hdf5libs::HDF5RawDataFile::record_id_t rid = std::make_pair(event, sequenceno);
+  auto sourceids = fRawDataFilePtr->get_source_ids(rid);
+  //MF_LOG_INFO("HDF5") << "Here 9";
+    
+  for (const auto &source_id : sourceids)  
+    {
+      // only want detector readout data (i.e. not trigger info)
+      if (source_id.subsystem != dunedaq::daqdataformats::SourceID::Subsystem::kDetectorReadout) continue;
+
+      // look through the geo IDs and see if we are in the right crate
+      auto gids = fRawDataFilePtr->get_geo_ids_for_source_id(rid, source_id);
+      for (const auto &gid : gids)
+        {
+          if (fLogLevel > 1)
+            {
+              std::cout << "TOADInput3Source Geoid: " << std::hex << gid << std::dec << std::endl;
+            }
+          uint16_t detid = 0xffff & gid;
+          dunedaq::detdataformats::DetID::Subdetector detidenum = static_cast<dunedaq::detdataformats::DetID::Subdetector>(detid);
+          auto subdetector_string = dunedaq::detdataformats::DetID::subdetector_to_string(detidenum);
+	  if (fLogLevel > 1)
+	    {
+	      std::cout << "TOADInput3Source subdetector string: " << subdetector_string << std::endl;
+	      //std::cout << "TOADInput3Source looking for subdet: " << " Put string here.  ND_LAr?" << std::endl;
+	      std::cout << "TOADInput3Source looking for subdet: " << "ND_GAr" << std::endl;
+	    }
+	  // I stopped copying code here ... Need to check the subdetector string and unpack the data.
+          //MF_LOG_INFO("HDF5") << "Here 10";
+
+	  if(subdetector_string == "ND_GAr")
+            {
+              //MF_LOG_INFO("HDF5") << "Here 11";
+
+              auto frag = fRawDataFilePtr->get_frag_ptr(rid, source_id);
+              //auto frag_hdr = frag->get_header();
+              //auto frag_ts = frag->get_trigger_timestamp();
+              size_t fhs = sizeof(dunedaq::daqdataformats::FragmentHeader);
+              auto frag_size = frag->get_size() - fhs;
+              MF_LOG_INFO("HDF5") << "frag_size "<<(int)frag_size<<" fhs "<<(int)fhs;
+              //int frag_start = 0;
+	      //int frag_count = 0;
+              int frag_interval=0;
+              gar::raw::ADCvector_t adc_vector;
+              //MF_LOG_INFO("HDF5") << "Here 12";
+              //int i_test = 0;
+              ULong64_t time;
+	      ULong64_t t0 =0;
+	      //short t_test = 1;
+//              for(frag_start = 0; frag_start<=(int)(frag_size); frag_start =+ frag_count) // frag_start<=number ; frag_start+=frag+interval
+	      while(frag_interval<(int)(frag_size))
+                {
+                auto fdp = static_cast<void*>(static_cast<char*>(frag->get_data()) + frag_interval);
+                auto toad_frame = reinterpret_cast<dunedaq::detdataformats::toad::TOADFrameOverlay*>(static_cast<char*>(fdp));
+                size_t nsamples = toad_frame->n_samples;
+                //MF_LOG_INFO("HDF5") << "frag_start "<< frag_start<<" n_samples "<< nsamples;
+		adc_vector.push_back(nsamples);
+		adc_vector.push_back(1);
+		adc_vector.push_back(4);
+		adc_vector.push_back(nsamples);
+                for (size_t i_samp=0; i_samp<nsamples; i_samp++)
+                {
+                  adc_vector.push_back(toad_frame->get_samples(i_samp));
+                  //MF_LOG_INFO("HDF5") << "samples"<<(int)(toad_frame->get_samples(i_samp));
+                }
+                auto chaninfo = channelMap->GetChanInfoFromTOADElements (toad_frame->fec);
+                unsigned int offline_chan = chaninfo.offlchan;
+                MF_LOG_INFO("HDF5") << "channel"<< (int)(toad_frame->fec) << "offlchan"<< offline_chan;
+                //unsigned int offline_chan = 0;
+                gar::raw::Compress_t compress = gar::raw::kZeroSuppression;
+		if(adc_vector[0] == 0){
+		  continue;
+		}
+		
+		if(frag_interval == 0){
+		  t0 = (ULong64_t)(toad_frame->tstmp);
+		}
+		time = (ULong64_t)(toad_frame->tstmp)-(ULong64_t)t0+1;
+                MF_LOG_INFO("HDF5") << "timestamps "<< time << "t0"<<t0;
+		//adc_vector[2] = 1;
+		//t_test++;
+                //t0 = 0;
+		//time = t0;
+                gar::raw::RawDigit rd(offline_chan, adc_vector.size(), adc_vector, compress, time);
+                adc_vector.clear();
+		(*rdcol).push_back(rd);
+                //frag_start = frag_start + (int)(toad_frame ->n_bytes);
+                frag_interval = frag_interval + (int)(toad_frame ->n_bytes);
+		//MF_LOG_INFO("HDF5") << "frag_interval, frag_start_sum "<<frag_interval<<" "<<(frag_start+frag_interval);
+                //MF_LOG_INFO("HDF5") << "Here 13 "<< frag_interval;
+                //i_test++;
+
+                }
+            }
+	}
+    }
+  MF_LOG_INFO("HDF5") << "Here 14";
+
+  put_product_in_principal(std::move(rdcol), *outE, pretend_module_name,
+                           "");
+  MF_LOG_INFO("HDF5") << "Here 15";
+
+  //put_product_in_principal(std::move(rd_timestamp), *outE, pretend_module_name,
+  //                         "trigger");
+
+  return true;
+}
+
+//typedef for shorthand
+namespace gar {
+  using TOADInput3Source = art::Source<TOADInput3Detail>;
+}
+
+
+DEFINE_ART_INPUT_SOURCE(gar::TOADInput3Source)

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/CMakeLists.txt
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/CMakeLists.txt
@@ -1,0 +1,22 @@
+include_directories("${dunedaqdataformats_DIR}/../../../include")
+include_directories("${dunedetdataformats_DIR}/../../../include")
+include_directories("${nlohmann_json_DIR}/../../../include")
+include_directories("${HighFive_DIR}/../../../include")
+art_make(
+	 LIBRARY_NAME dunedaqhdf5utils3
+         LIB_LIBRARIES
+	 cetlib::cetlib
+         cetlib_except::cetlib_except
+         messagefacility::MF_MessageLogger
+         HDF5::HDF5
+         pthread
+         z
+)
+
+install_headers()
+install_source()
+
+add_subdirectory(hdf5filelayout)
+add_subdirectory(hdf5sourceidmaps)
+add_subdirectory(hdf5rawdatafile)
+

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5FileLayout.cpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5FileLayout.cpp
@@ -1,0 +1,343 @@
+/**
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ *
+ */
+
+#include "HDF5FileLayout.hpp"
+
+#include <stdexcept>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace hdf5libs {
+
+HDF5FileLayout::HDF5FileLayout(hdf5filelayout::FileLayoutParams conf, uint32_t version) // NOLINT(build/unsigned)
+  : m_conf_params(conf)
+  , m_version(version)
+{
+  if (m_version < 2)
+    m_conf_params = get_v0_file_layout_params();
+
+  fill_path_params_maps(m_conf_params);
+
+  check_config();
+}
+
+void
+HDF5FileLayout::check_config()
+{
+  // for now, don't do additional config checks for old versions
+  if (m_version < 2)
+    return;
+
+  if (m_conf_params.record_name_prefix.compare("TriggerRecord") == 0) {
+    if (m_conf_params.digits_for_sequence_number == 0) {
+      MF_LOG_ERROR("HDF5FileLayout.cpp") << " File Layout Sequence IDs Cannot Be Zero 4";
+      m_conf_params.digits_for_sequence_number = 4;
+    }
+  } else if (m_conf_params.record_name_prefix.compare("TimeSlice") == 0) {
+    if (m_conf_params.digits_for_sequence_number != 0) {
+      MF_LOG_WARNING("HDF5FileLayout.cpp") << " Invalid Sequence Digits " << m_conf_params.record_name_prefix << " 0";
+      m_conf_params.digits_for_sequence_number = 0;
+    }
+  } else {
+    throw cet::exception("HDF5FileLayout.cpp") << " Invalid Record Name " << m_conf_params.record_name_prefix;
+  }
+}
+
+hdf5filelayout::PathParams
+HDF5FileLayout::get_path_params(daqdataformats::SourceID::Subsystem type) const
+{
+  try {
+    return m_path_params_map.at(type);
+  } catch (std::out_of_range&) {
+    throw cet::exception("HDF5FileLayout.cpp") << " FileLayoutUnconfiguredSubsystem " << type << " " << daqdataformats::SourceID::subsystem_to_string(type);
+  }
+}
+
+std::string
+HDF5FileLayout::get_record_number_string(uint64_t record_number, // NOLINT(build/unsigned)
+                                         daqdataformats::sequence_number_t seq_num) const
+{
+  std::ostringstream record_number_string;
+
+  int width = m_conf_params.digits_for_record_number;
+
+  if (record_number >= m_powers_ten[m_conf_params.digits_for_record_number]) {
+    MF_LOG_WARNING("HDF5FileLayout.cpp") << " File Layout Not Enough Digits For Path " << record_number << " " << m_conf_params.digits_for_record_number;
+    width = 0; // tells it to revert to normal width
+  }
+
+  record_number_string << m_conf_params.record_name_prefix << std::setw(width) << std::setfill('0') << record_number;
+
+  if (m_conf_params.digits_for_sequence_number > 0) {
+
+    width = m_conf_params.digits_for_sequence_number;
+    if (seq_num >= m_powers_ten[m_conf_params.digits_for_sequence_number]) {
+      MF_LOG_WARNING("HDF5FileLayout.cpp") << " File Layout Not Enough Digits For Path " << seq_num << " " << m_conf_params.digits_for_sequence_number;
+      width = 0; // tells it to revert to normal width
+    }
+    record_number_string << "." << std::setw(width) << std::setfill('0') << seq_num;
+  }
+
+  return record_number_string.str();
+}
+
+std::string
+HDF5FileLayout::get_trigger_number_string(daqdataformats::trigger_number_t trig_num,
+                                          daqdataformats::sequence_number_t seq_num) const
+{
+  return get_record_number_string(trig_num, seq_num);
+}
+
+std::string
+HDF5FileLayout::get_timeslice_number_string(daqdataformats::timeslice_number_t ts_num) const
+{
+  return get_record_number_string(ts_num);
+}
+
+/**
+ * @brief get the correct path for the TriggerRecordHeader
+ */
+std::vector<std::string>
+HDF5FileLayout::get_path_elements(const daqdataformats::TriggerRecordHeader& trh) const
+{
+
+  std::vector<std::string> path_elements;
+
+  // first the Trigger string
+  path_elements.push_back(get_trigger_number_string(trh.get_trigger_number(), trh.get_sequence_number()));
+
+  // then the RawData group name
+  path_elements.push_back(m_conf_params.raw_data_group_name);
+
+  // then the SourceID plus record header name
+  path_elements.push_back(trh.get_header().element_id.to_string() + "_" + m_conf_params.record_header_dataset_name);
+
+  return path_elements;
+}
+
+/**
+ * @brief get the correct path for the TimeSliceHeader
+ */
+std::vector<std::string>
+HDF5FileLayout::get_path_elements(const daqdataformats::TimeSliceHeader& tsh) const
+{
+
+  std::vector<std::string> path_elements;
+
+  // first the Trigger string
+  path_elements.push_back(get_timeslice_number_string(tsh.timeslice_number));
+
+  // then the RawData group name
+  path_elements.push_back(m_conf_params.raw_data_group_name);
+
+  // then the SourceID plus record header name
+  path_elements.push_back(tsh.element_id.to_string() + "_" + m_conf_params.record_header_dataset_name);
+
+  return path_elements;
+}
+
+/**
+ * @brief get the correct path for the Fragment
+ */
+std::vector<std::string>
+HDF5FileLayout::get_path_elements(const daqdataformats::FragmentHeader& fh) const
+{
+
+  std::vector<std::string> path_elements;
+
+  // first the Trigger string
+  // note, this still works for TimeSlices through enforced proper configuration of layout parameters
+  path_elements.push_back(get_trigger_number_string(fh.trigger_number, fh.sequence_number));
+
+  // then the RawData group name
+  path_elements.push_back(m_conf_params.raw_data_group_name);
+
+  // then the SourceID plus FragmentType
+  path_elements.push_back(fh.element_id.to_string() + "_" + daqdataformats::fragment_type_to_string(static_cast<daqdataformats::FragmentType>(fh.fragment_type)));
+
+  return path_elements;
+}
+
+/**
+ * @brief get the full path for a record header dataset based on trig/seq number
+ */
+std::string
+HDF5FileLayout::get_record_header_path(uint64_t rec_num, // NOLINT (build/unsigned)
+                                       daqdataformats::sequence_number_t seq_num) const
+{
+  return get_record_number_string(rec_num, seq_num) + "/" + m_conf_params.record_header_dataset_name;
+}
+
+/**
+ * @brief get the full path for a TriggerRecordHeader dataset based on trig/seq number
+ */
+std::string
+HDF5FileLayout::get_trigger_record_header_path(daqdataformats::trigger_number_t trig_num,
+                                               daqdataformats::sequence_number_t seq_num) const
+{
+  return get_trigger_number_string(trig_num, seq_num) + "/" + m_conf_params.record_header_dataset_name;
+}
+
+/**
+ * @brief get the full path for a TimeSliceHeader dataset based on ts number
+ */
+std::string
+HDF5FileLayout::get_timeslice_header_path(daqdataformats::timeslice_number_t ts_num) const
+{
+  return get_timeslice_number_string(ts_num) + "/" + m_conf_params.record_header_dataset_name;
+}
+
+/**
+ * @brief get the full path for a Fragment dataset based on trig/seq number and element ID
+ */
+std::string
+HDF5FileLayout::get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                  daqdataformats::sequence_number_t seq_num,
+                                  daqdataformats::SourceID element_id) const
+{
+
+  auto const& path_params = get_path_params(element_id.subsystem);
+
+  std::ostringstream path_string;
+  path_string << get_trigger_number_string(trig_num, seq_num) << "/" << path_params.detector_group_name << "/"
+              << path_params.element_name_prefix << std::setw(path_params.digits_for_element_number)
+              << std::setfill('0') << element_id.id;
+  return path_string.str();
+}
+
+/**
+ * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
+ */
+std::string
+HDF5FileLayout::get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                  daqdataformats::sequence_number_t seq_num,
+                                  daqdataformats::SourceID::Subsystem type,
+                                  uint32_t element_id) const // NOLINT(build/unsigned)
+{
+  daqdataformats::SourceID sid{ type, element_id };
+  return get_fragment_path(trig_num, seq_num, sid);
+}
+
+/**
+ * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
+ */
+std::string
+HDF5FileLayout::get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                  daqdataformats::sequence_number_t seq_num,
+                                  const std::string& typestring,
+                                  uint32_t element_id) const // NOLINT(build/unsigned)
+{
+  daqdataformats::SourceID sid{ daqdataformats::SourceID::string_to_subsystem(typestring), element_id };
+  return get_fragment_path(trig_num, seq_num, sid);
+}
+
+/**
+ * @brief get the path for a Fragment type group based on trig/seq number and type
+ */
+std::string
+HDF5FileLayout::get_fragment_type_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                       daqdataformats::sequence_number_t seq_num,
+                                       daqdataformats::SourceID::Subsystem type) const
+{
+  auto const& path_params = get_path_params(type);
+
+  std::ostringstream path_string;
+  path_string << get_trigger_number_string(trig_num, seq_num) << "/" << path_params.detector_group_name;
+  return path_string.str();
+}
+
+/**
+ * @brief get the path for a Fragment type group based on trig/seq number and type
+ */
+std::string
+HDF5FileLayout::get_fragment_type_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                       daqdataformats::sequence_number_t seq_num,
+                                       std::string typestring) const
+{
+  return get_fragment_type_path(trig_num, seq_num, daqdataformats::SourceID::string_to_subsystem(typestring));
+}
+
+daqdataformats::SourceID
+HDF5FileLayout::get_source_id_from_path_elements(std::vector<std::string> const& path_elements) const
+{
+  // ignore first path element, which is for the record group
+  // second path element is detector name.
+  daqdataformats::SourceID::Subsystem systype = m_detector_group_name_to_type_map.at(path_elements[1]);
+
+  // get back the path parameters for this system type from the file layout
+  auto path_params = get_path_params(systype);
+
+  // fourth path element is element. remove prefix and translate to numbers
+  auto ele_id = std::stoi(path_elements[3].substr(path_params.element_name_prefix.size()));
+
+  return daqdataformats::SourceID(systype, ele_id);
+}
+
+void
+HDF5FileLayout::fill_path_params_maps(hdf5filelayout::FileLayoutParams const& flp)
+{
+  for (auto const& path_param : flp.path_param_list) {
+    auto sys_type = daqdataformats::SourceID::string_to_subsystem(path_param.detector_group_type);
+
+    if (sys_type == daqdataformats::SourceID::Subsystem::kUnknown)
+      throw cet::exception("HDF5FileLayout.cpp") << " File Layout Invalid Subsystem " << path_param.detector_group_type;
+
+    m_path_params_map[sys_type] = path_param;
+    m_detector_group_name_to_type_map[path_param.detector_group_name] = sys_type;
+  }
+}
+
+/**
+ * @brief Version0 FileLayout parameters, for backward compatibility
+ */
+hdf5filelayout::FileLayoutParams
+HDF5FileLayout::get_v0_file_layout_params()
+{
+  hdf5filelayout::FileLayoutParams flp;
+  flp.record_name_prefix = "TriggerRecord";
+  flp.digits_for_record_number = 6;
+  flp.digits_for_sequence_number = 0;
+  flp.record_header_dataset_name = "TriggerRecordHeader";
+
+  hdf5filelayout::PathParams pp;
+
+  pp.detector_group_type = "TPC";
+  pp.detector_group_name = "TPC";
+  pp.element_name_prefix = "Link";
+  pp.digits_for_element_number = 2;
+  flp.path_param_list.push_back(pp);
+
+  pp.detector_group_type = "PDS";
+  pp.detector_group_name = "PDS";
+  pp.element_name_prefix = "Element";
+  pp.digits_for_element_number = 2;
+  flp.path_param_list.push_back(pp);
+
+  pp.detector_group_type = "NDLArTPC";
+  pp.detector_group_name = "NDLArTPC";
+  pp.element_name_prefix = "Element";
+  pp.digits_for_element_number = 2;
+  flp.path_param_list.push_back(pp);
+
+  pp.detector_group_type = "NDLArPDS";
+  pp.detector_group_name = "NDLArPDS";
+  pp.element_name_prefix = "Element";
+  pp.digits_for_element_number = 2;
+  flp.path_param_list.push_back(pp);
+
+  pp.detector_group_type = "DataSelection";
+  pp.detector_group_name = "Trigger";
+  pp.element_name_prefix = "Element";
+  pp.digits_for_element_number = 2;
+  flp.path_param_list.push_back(pp);
+
+  return flp;
+}
+
+} // namespace hdf5libs
+} // namespace dunedaq

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5FileLayout.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5FileLayout.hpp
@@ -1,0 +1,231 @@
+/**
+ * @file HDF5FileLayout.hpp
+ *
+ * FileLayoutObject that is used to describe/provide instructions for
+ * organizing DUNE DAQ HDF5 files.
+ *
+ * WK 02.02.2022 -- Future could make a FileLayout descriptor per SystemType
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ * 
+ * Modified April 2024 Tom Junk -- update from dunedaqhdf5utils2
+ */
+
+#ifndef HDF5LIBS_INCLUDE_HDF5LIBS_HDF5FILELAYOUT_HPP_
+#define HDF5LIBS_INCLUDE_HDF5LIBS_HDF5FILELAYOUT_HPP_
+
+#include "hdf5filelayout/Structs.hpp"
+
+#include "daqdataformats/v4_4_0/Fragment.hpp"
+#include "daqdataformats/v4_4_0/SourceID.hpp"
+#include "daqdataformats/v4_4_0/TimeSliceHeader.hpp"
+#include "daqdataformats/v4_4_0/TriggerRecordHeader.hpp"
+
+#include "nlohmann/json.hpp"
+
+#include <cstdint>
+#include <iomanip>
+#include <limits>
+#include <map>
+#include <memory>
+#include <sstream>
+#include <string>
+#include <vector>
+
+// Offline includes
+
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
+
+namespace dunedaq {
+
+namespace hdf5libs {
+
+class HDF5FileLayout
+{
+public:
+  /**
+   * @brief Constructor from json conf, used in DataWriter. Version always most recent.
+   */
+  explicit HDF5FileLayout(hdf5filelayout::FileLayoutParams conf, uint32_t version = 5); // NOLINT(build/unsigned)
+
+  uint32_t get_version() const noexcept // NOLINT(build/unsigned)
+  {
+    return m_version;
+  }
+
+  std::string get_record_name_prefix() const noexcept { return m_conf_params.record_name_prefix; }
+
+  int get_digits_for_record_number() const noexcept { return m_conf_params.digits_for_record_number; }
+
+  int get_digits_for_sequence_number() const noexcept { return m_conf_params.digits_for_sequence_number; }
+
+  std::string get_record_header_dataset_name() const noexcept { return m_conf_params.record_header_dataset_name; }
+
+  std::map<daqdataformats::SourceID::Subsystem, hdf5filelayout::PathParams> get_path_params_map() const
+  {
+    return m_path_params_map;
+  }
+
+  hdf5filelayout::PathParams get_path_params(daqdataformats::SourceID::Subsystem type) const;
+
+  hdf5filelayout::FileLayoutParams get_file_layout_params() const { return m_conf_params; }
+
+  /**
+   * @brief get string for record number
+   */
+  std::string get_record_number_string(uint64_t record_number, // NOLINT(build/unsigned)
+                                       daqdataformats::sequence_number_t seq_num = 0) const;
+
+  /**
+   * @brief get string for Trigger number
+   */
+  std::string get_trigger_number_string(daqdataformats::trigger_number_t trig_num,
+                                        daqdataformats::sequence_number_t seq_num = 0) const;
+
+  /**
+   * @brief get string for TimeSlice number
+   */
+  std::string get_timeslice_number_string(daqdataformats::timeslice_number_t ts_num) const;
+
+  /**
+   * @brief get the correct path for the TriggerRecordHeader
+   */
+  std::vector<std::string> get_path_elements(const daqdataformats::TriggerRecordHeader& trh) const;
+
+  /**
+   * @brief get the correct path for the TimeSliceHeader
+   */
+  std::vector<std::string> get_path_elements(const daqdataformats::TimeSliceHeader& tsh) const;
+
+  /**
+   * @brief get the correct path for the Fragment
+   */
+  std::vector<std::string> get_path_elements(const daqdataformats::FragmentHeader& fh) const;
+
+  /**
+   * @brief extract Fragment GeoID given path elements
+   */
+  daqdataformats::SourceID get_source_id_from_path_elements(std::vector<std::string> const& path_elements) const;
+
+  /**
+   * @brief get the full path for a record header dataset based on trig/seq number
+   */
+  std::string get_record_header_path(uint64_t rec_num, // NOLINT (build/unsigned)
+                                     daqdataformats::sequence_number_t seq_num = 0) const;
+
+  /**
+   * @brief get the full path for a TriggerRecordHeader dataset based on trig/seq number
+   */
+  std::string get_trigger_record_header_path(daqdataformats::trigger_number_t trig_num,
+                                             daqdataformats::sequence_number_t seq_num = 0) const;
+
+  /**
+   * @brief get the full path for a TimesliceHeader dataset based on ts number
+   */
+  std::string get_timeslice_header_path(daqdataformats::timeslice_number_t ts_num) const;
+
+  /**
+   * @brief get the full path for a Fragment dataset based on trig/seq number and element ID
+   */
+  std::string get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                daqdataformats::sequence_number_t seq_num,
+                                daqdataformats::SourceID element_id) const;
+  /**
+   * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
+   */
+  std::string get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                daqdataformats::sequence_number_t seq_num,
+                                daqdataformats::SourceID::Subsystem type,
+                                uint32_t element_id) const; // NOLINT(build/unsigned)
+
+  /**
+   * @brief get the full path for a Fragment dataset based on trig/seq number, give element_id pieces
+   */
+  std::string get_fragment_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                daqdataformats::sequence_number_t seq_num,
+                                const std::string& typestring,
+                                uint32_t element_id) const; // NOLINT(build/unsigned)
+
+  /**
+   * @brief get the path for a Fragment type group based on trig/seq number and type
+   */
+  std::string get_fragment_type_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                     daqdataformats::sequence_number_t seq_num,
+                                     daqdataformats::SourceID::Subsystem type) const;
+
+  /**
+   * @brief get the path for a Fragment type group based on trig/seq number and type
+   */
+  std::string get_fragment_type_path(uint64_t trig_num, // NOLINT(build/unsigned)
+                                     daqdataformats::sequence_number_t seq_num,
+                                     std::string typestring) const;
+
+private:
+  /**
+   * @brief FileLayout configuration parameters
+   */
+  hdf5filelayout::FileLayoutParams m_conf_params;
+
+  /**
+   * @brief version number
+   */
+  uint32_t m_version; // NOLINT(build/unsigned)
+
+  /**
+   * @brief map translation for SourceID::Subsystem to dataset path parameters
+   */
+  std::map<daqdataformats::SourceID::Subsystem, hdf5filelayout::PathParams> m_path_params_map;
+
+  /**
+   * @brief map translation for the detector group name to SourceID::Subsystem
+   */
+  std::map<std::string, daqdataformats::SourceID::Subsystem> m_detector_group_name_to_type_map;
+
+  // quick powers of ten lookup
+  constexpr static uint64_t m_powers_ten[] // NOLINT(build/unsigned)
+    = {
+        1,                    // 1e0
+        10,                   // 1e1
+        100,                  // 1e2
+        1000,                 // 1e3
+        10000,                // 1e4
+        100000,               // 1e5
+        1000000,              // 1e6
+        10000000,             // 1e7
+        100000000,            // 1e8
+        1000000000,           // 1e9
+        10000000000,          // 1e10
+        100000000000,         // 1e11
+        1000000000000,        // 1e12
+        10000000000000,       // 1e13
+        100000000000000,      // 1e14
+        1000000000000000,     // 1e15
+        10000000000000000,    // 1e16
+        100000000000000000,   // 1e17
+        1000000000000000000,  // 1e18
+        10000000000000000000u // 1e19
+      };
+
+  /**
+   * @brief Fill path parameters maps from FileLayoutParams
+   */
+  void fill_path_params_maps(hdf5filelayout::FileLayoutParams const& flp);
+
+  /**
+   * @brief Version0 FileLayout parameters, for backward compatibility
+   */
+  hdf5filelayout::FileLayoutParams get_v0_file_layout_params();
+
+  /**
+   * @brief Check configuration for any errors.
+   */
+  void check_config();
+};
+
+} // namespace hdf5libs
+} // namespace dunedaq
+
+#endif // HDF5LIBS_INCLUDE_HDF5LIBS_HDF5FILELAYOUT_HPP_

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5RawDataFile.cpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5RawDataFile.cpp
@@ -1,0 +1,1189 @@
+/**
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ *
+ * modified April 23, 2024 for dune-daq v4.4.0
+ */
+
+#include "HDF5RawDataFile.hpp"
+#include "hdf5filelayout/Nljs.hpp"
+
+#include <algorithm>
+#include <filesystem>
+#include <map>
+#include <memory>
+#include <set>
+#include <sstream>
+#include <string>
+#include <utility>
+#include <vector>
+
+namespace dunedaq {
+namespace hdf5libs {
+
+constexpr uint32_t MAX_FILELAYOUT_VERSION = 4294967295; // NOLINT(build/unsigned)
+
+/**
+ * @brief Constructor for writing a new file
+ */
+HDF5RawDataFile::HDF5RawDataFile(std::string file_name,
+                                 daqdataformats::run_number_t run_number,
+                                 size_t file_index,
+                                 std::string application_name,
+                                 const hdf5filelayout::FileLayoutParams& fl_params,
+                                 hdf5rawdatafile::SrcIDGeoIDMap srcid_geoid_map,
+                                 std::string inprogress_filename_suffix,
+                                 unsigned open_flags)
+  : m_bare_file_name(file_name)
+  , m_open_flags(open_flags)
+{
+
+  // check and make sure that the file isn't ReadOnly
+  if (m_open_flags == HighFive::File::ReadOnly) {
+    throw cet::exception("HDF5RawDataFile") << " Incompatible Open Flags " << file_name << " " << m_open_flags;
+  }
+
+  auto filename_to_open = m_bare_file_name + inprogress_filename_suffix;
+
+  // do the file open
+  try {
+    m_file_ptr.reset(new HighFive::File(filename_to_open, m_open_flags));
+  } catch (std::exception const& excpt) {
+    throw cet::exception("HDF5RawDataFile") << " File Open Failed " << filename_to_open << " " << excpt.what();
+  }
+
+  m_recorded_size = 0;
+
+  int64_t timestamp =
+    std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+  std::string file_creation_timestamp = std::to_string(timestamp);
+
+  MF_LOG_DEBUG("HDF5RawDataFile.cpp") << "Created HDF5 file (" << file_name << ") at time " << file_creation_timestamp << " .";
+
+  // write some file attributes
+  write_attribute("run_number", run_number);
+  write_attribute("file_index", file_index);
+  write_attribute("creation_timestamp", file_creation_timestamp);
+  write_attribute("application_name", application_name);
+
+  // set the file layout contents
+  m_file_layout_ptr.reset(new HDF5FileLayout(fl_params));
+  write_file_layout();
+
+  // write the SourceID-related attributes
+  HDF5SourceIDHandler::populate_source_id_geo_id_map(srcid_geoid_map, m_file_level_source_id_geo_id_map);
+  HDF5SourceIDHandler::store_file_level_geo_id_info(*m_file_ptr, m_file_level_source_id_geo_id_map);
+
+  // write the record type
+  m_record_type = fl_params.record_name_prefix;
+  write_attribute("record_type", m_record_type);
+}
+
+
+HDF5RawDataFile::~HDF5RawDataFile()
+{
+  if (m_file_ptr.get() != nullptr && m_open_flags != HighFive::File::ReadOnly) {
+    write_attribute("recorded_size", m_recorded_size);
+
+    int64_t timestamp =
+      std::chrono::duration_cast<std::chrono::milliseconds>(std::chrono::system_clock::now().time_since_epoch()).count();
+    std::string file_closing_timestamp = std::to_string(timestamp);
+    write_attribute("closing_timestamp", file_closing_timestamp);
+
+    m_file_ptr->flush();
+
+    // rename file to the bare name
+    std::filesystem::rename(m_file_ptr->getName(), m_bare_file_name);
+  }
+
+  // explicit destruction; not really needed, but nice to be clear...
+  m_file_ptr.reset();
+  m_file_layout_ptr.reset();
+}
+
+/**
+ * @brief Write a TriggerRecord to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::TriggerRecord& tr)
+{
+  // the source_id_path map that we will build up as we write the TR header
+  // and fragments (and then write the map into the HDF5 TR_record Group)
+  HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;
+
+  // the map of fragment types to SourceIDS
+  HDF5SourceIDHandler::fragment_type_source_id_map_t fragment_type_source_id_map;
+
+  // the map of subdetectors to SourceIDS
+  HDF5SourceIDHandler::subdetector_source_id_map_t subdetector_source_id_map;
+
+  // write the record header into the HDF5 file/group
+  HighFive::Group record_level_group = write(tr.get_header_ref(), source_id_path_map);
+
+  // store the SourceID of the record header in the HDF5 file/group
+  // (since there should only be one entry in the map at this point, we'll take advantage of that...)
+  for (auto const& source_id_path : source_id_path_map) {
+    HDF5SourceIDHandler::store_record_header_source_id(record_level_group, source_id_path.first);
+  }
+
+  // write all of the fragments into the HDF5 file/group
+  for (auto const& frag_ptr : tr.get_fragments_ref()) {
+    write(*frag_ptr, source_id_path_map);
+    HDF5SourceIDHandler::add_fragment_type_source_id_to_map(
+      fragment_type_source_id_map, frag_ptr->get_fragment_type(), frag_ptr->get_element_id());
+    HDF5SourceIDHandler::add_subdetector_source_id_to_map(
+      subdetector_source_id_map,
+      static_cast<detdataformats::DetID::Subdetector>(frag_ptr->get_detector_id()),
+      frag_ptr->get_element_id());
+  }
+
+  // store all of the record-level maps in the HDF5 file/group
+  HDF5SourceIDHandler::store_record_level_path_info(record_level_group, source_id_path_map);
+  HDF5SourceIDHandler::store_record_level_fragment_type_map(record_level_group, fragment_type_source_id_map);
+  HDF5SourceIDHandler::store_record_level_subdetector_map(record_level_group, subdetector_source_id_map);
+}
+
+/**
+ * @brief Write a TimeSlice to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::TimeSlice& ts)
+{
+  // the source_id_path map that we will build up as we write the TR header
+  // and fragments (and then write the map into the HDF5 TR_record Group)
+  HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;
+
+  // the map of fragment types to SourceIDS
+  HDF5SourceIDHandler::fragment_type_source_id_map_t fragment_type_source_id_map;
+
+  // the map of subdetectors to SourceIDS
+  HDF5SourceIDHandler::subdetector_source_id_map_t subdetector_source_id_map;
+
+  // write the record header into the HDF5 file/group
+  HighFive::Group record_level_group = write(ts.get_header(), source_id_path_map);
+
+  // store the SourceID of the record header in the HDF5 file/group
+  // (since there should only be one entry in the map at this point, we'll take advantage of that...)
+  for (auto const& source_id_path : source_id_path_map) {
+    HDF5SourceIDHandler::store_record_header_source_id(record_level_group, source_id_path.first);
+  }
+
+  // write all of the fragments into the HDF5 file/group
+  for (auto const& frag_ptr : ts.get_fragments_ref()) {
+    write(*frag_ptr, source_id_path_map);
+    HDF5SourceIDHandler::add_fragment_type_source_id_to_map(
+      fragment_type_source_id_map, frag_ptr->get_fragment_type(), frag_ptr->get_element_id());
+    HDF5SourceIDHandler::add_subdetector_source_id_to_map(
+      subdetector_source_id_map,
+      static_cast<detdataformats::DetID::Subdetector>(frag_ptr->get_detector_id()),
+      frag_ptr->get_element_id());
+  }
+
+  // store all of the record-level maps in the HDF5 file/group
+  HDF5SourceIDHandler::store_record_level_path_info(record_level_group, source_id_path_map);
+  HDF5SourceIDHandler::store_record_level_fragment_type_map(record_level_group, fragment_type_source_id_map);
+  HDF5SourceIDHandler::store_record_level_subdetector_map(record_level_group, subdetector_source_id_map);
+}
+
+/**
+ * @brief Write a TriggerRecordHeader to the file.
+ */
+HighFive::Group
+HDF5RawDataFile::write(const daqdataformats::TriggerRecordHeader& trh,
+                       HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(trh),
+             static_cast<const char*>(trh.get_storage_location()),
+             trh.get_total_size_bytes());
+  m_recorded_size += std::get<0>(write_results);
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, trh.get_header().element_id, std::get<1>(write_results));
+  return std::get<2>(write_results);
+}
+
+/**
+ * @brief Write a TimeSliceHeader to the file.
+ */
+HighFive::Group
+HDF5RawDataFile::write(const daqdataformats::TimeSliceHeader& tsh, HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(tsh), (const char*)(&tsh), sizeof(daqdataformats::TimeSliceHeader));
+  m_recorded_size += std::get<0>(write_results);
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, tsh.element_id, std::get<1>(write_results));
+  return std::get<2>(write_results);
+}
+
+/**
+ * @brief Write a Fragment to the file.
+ */
+void
+HDF5RawDataFile::write(const daqdataformats::Fragment& frag, HDF5SourceIDHandler::source_id_path_map_t& path_map)
+{
+  std::tuple<size_t, std::string, HighFive::Group> write_results =
+    do_write(m_file_layout_ptr->get_path_elements(frag.get_header()),
+             static_cast<const char*>(frag.get_storage_location()),
+             frag.get_size());
+  m_recorded_size += std::get<0>(write_results);
+
+  daqdataformats::SourceID source_id = frag.get_element_id();
+  HDF5SourceIDHandler::add_source_id_path_to_map(path_map, source_id, std::get<1>(write_results));
+}
+
+/**
+ * @brief write the file layout
+ */
+void
+HDF5RawDataFile::write_file_layout()
+{
+  hdf5filelayout::data_t fl_json;
+  hdf5filelayout::to_json(fl_json, m_file_layout_ptr->get_file_layout_params());
+  write_attribute("filelayout_params", fl_json.dump());
+  write_attribute("filelayout_version", m_file_layout_ptr->get_version());
+}
+
+/**
+ * @brief write bytes to a dataset in the file, at the appropriate path
+ */
+std::tuple<size_t, std::string, HighFive::Group>
+HDF5RawDataFile::do_write(std::vector<std::string> const& group_and_dataset_path_elements,
+                          const char* raw_data_ptr,
+                          size_t raw_data_size_bytes)
+{
+  const std::string dataset_name = group_and_dataset_path_elements.back();
+
+  // create top level group if needed
+  std::string const& top_level_group_name = group_and_dataset_path_elements.at(0);
+  if (!m_file_ptr->exist(top_level_group_name))
+    m_file_ptr->createGroup(top_level_group_name);
+
+  // setup sub_group to work with
+  HighFive::Group sub_group = m_file_ptr->getGroup(top_level_group_name);
+  if (!sub_group.isValid()) {
+    throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << top_level_group_name;
+  }
+  HighFive::Group top_level_group = sub_group;
+
+  // Create the remaining subgroups
+  for (size_t idx = 1; idx < group_and_dataset_path_elements.size() - 1; ++idx) {
+    // group_dataset.size()-1 because the last element is the dataset
+    std::string const& child_group_name = group_and_dataset_path_elements[idx];
+    if (child_group_name.empty()) {
+      throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << child_group_name;
+    }
+    if (!sub_group.exist(child_group_name)) {
+      sub_group.createGroup(child_group_name);
+    }
+    HighFive::Group child_group = sub_group.getGroup(child_group_name);
+    if (!child_group.isValid()) {
+      throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Group: " << child_group_name;
+    }
+    sub_group = child_group;
+  }
+
+  // Create dataset
+  HighFive::DataSpace data_space = HighFive::DataSpace({ raw_data_size_bytes, 1 });
+  HighFive::DataSetCreateProps data_set_create_props;
+  HighFive::DataSetAccessProps data_set_access_props;
+
+  auto data_set = sub_group.createDataSet<char>(dataset_name, data_space, data_set_create_props, data_set_access_props);
+  if (data_set.isValid()) {
+    data_set.write_raw(raw_data_ptr);
+    m_file_ptr->flush();
+    return std::make_tuple(raw_data_size_bytes, data_set.getPath(), top_level_group);
+  } else {
+    throw cet::exception("HDF5RawDataFile") << " Invalid HDF5 Dataset: " << dataset_name << " " <<  m_file_ptr->getName();
+  }
+}
+
+/**
+ * @brief Constructor for reading a file
+ */
+HDF5RawDataFile::HDF5RawDataFile(const std::string& file_name)
+  : m_open_flags(HighFive::File::ReadOnly)
+{
+  // do the file open
+  try {
+    m_file_ptr = std::make_unique<HighFive::File>(file_name, m_open_flags);
+  } catch (std::exception const& excpt) {
+    throw cet::exception("HDF5RawDataFile") << " File open failure: " << file_name << " " << excpt.what();
+  }
+
+  if (m_file_ptr->hasAttribute("recorded_size"))
+    m_recorded_size = get_attribute<size_t>("recorded_size");
+  else
+    m_recorded_size = 0;
+
+  read_file_layout();
+
+  if (m_file_ptr->hasAttribute("record_type"))
+    m_record_type = get_attribute<std::string>("record_type");
+  else
+    m_record_type = m_file_layout_ptr->get_record_name_prefix();
+
+  check_file_layout();
+
+  // HDF5SourceIDHandler operations need to come *after* read_file_layout()
+  // because they count on the filelayout_version, which is set in read_file_layout().
+  HDF5SourceIDHandler sid_handler(get_version());
+  sid_handler.fetch_file_level_geo_id_info(*m_file_ptr, m_file_level_source_id_geo_id_map);
+}
+
+void
+HDF5RawDataFile::read_file_layout()
+{
+  hdf5filelayout::FileLayoutParams fl_params;
+  uint32_t version = 0; // NOLINT(build/unsigned)
+
+  std::string fl_str;
+  try {
+    fl_str = get_attribute<std::string>("filelayout_params");
+    hdf5filelayout::data_t fl_json = nlohmann::json::parse(fl_str);
+    hdf5filelayout::from_json(fl_json, fl_params);
+
+    version = get_attribute<uint32_t>("filelayout_version"); // NOLINT(build/unsigned)
+
+  } catch (cet::exception const&) { 
+    MF_LOG_INFO("HDF5RawDataFile.cpp") << "Missing File Layout " << version; 
+  }
+
+  // now reset the HDF5Filelayout object
+  m_file_layout_ptr.reset(new HDF5FileLayout(fl_params, version));
+}
+
+void
+HDF5RawDataFile::check_file_layout()
+{
+  if (get_version() < 2)
+    return;
+
+  std::string record_type = get_attribute<std::string>("record_type");
+  if (record_type.compare(m_file_layout_ptr->get_record_name_prefix()) != 0)
+    throw cet::exception("HDF5RawDataFile.cpp") << "Bad Record Type: " << record_type << " " << m_file_layout_ptr->get_record_name_prefix();
+}
+
+void
+HDF5RawDataFile::check_record_type(std::string rt_name)
+{
+  if (get_version() < 2)
+    return;
+
+  if (m_file_layout_ptr->get_record_name_prefix().compare(rt_name) != 0)
+    throw cet::exception("HDF5RawDataFile.cpp") << "Wrong Record Type Requested: " << rt_name << " " << m_file_layout_ptr->get_record_name_prefix();
+}
+
+// HDF5 Utility function to recursively traverse a file
+void
+HDF5RawDataFile::explore_subgroup(const HighFive::Group& parent_group,
+                                  std::string relative_path,
+                                  std::vector<std::string>& path_list)
+{
+  if (relative_path.size() > 0 && relative_path.compare(relative_path.size() - 1, 1, "/") == 0)
+    relative_path.pop_back();
+
+  std::vector<std::string> childNames = parent_group.listObjectNames();
+
+  for (auto& child_name : childNames) {
+    std::string full_path = relative_path + "/" + child_name;
+    HighFive::ObjectType child_type = parent_group.getObjectType(child_name);
+
+    if (child_type == HighFive::ObjectType::Dataset) {
+      path_list.push_back(full_path);
+    } else if (child_type == HighFive::ObjectType::Group) {
+      HighFive::Group child_group = parent_group.getGroup(child_name);
+      // start the recusion
+      std::string new_path = relative_path + "/" + child_name;
+      explore_subgroup(child_group, new_path, path_list);
+    }
+  }
+}
+
+void
+HDF5RawDataFile::add_record_level_info_to_caches_if_needed(record_id_t rid)
+{
+  // we should probably check that all relevant caches have an entry for the
+  // specified record ID, but we will just check one, in the interest of
+  // performance, and trust the "else" part of this routine to fill in *all*
+  // of the appropriate caches
+  if (m_source_id_path_cache.count(rid) != 0) {
+    return;
+  }
+
+  // create the handler to do the work
+  HDF5SourceIDHandler sid_handler(get_version());
+
+  // determine the HDF5 Group that corresponds to the specified record
+  std::string record_level_group_name = m_file_layout_ptr->get_record_number_string(rid.first, rid.second);
+  HighFive::Group record_group = m_file_ptr->getGroup(record_level_group_name);
+  if (!record_group.isValid()) {
+    throw cet::exception("HDF5RawDataFile.cpp") << "Invalid HDF5 Group: " << record_level_group_name;
+  }
+
+  // start with a copy of the file-level source-id-to-geo-id map and give the
+  // handler an opportunity to add any record-level additions
+  HDF5SourceIDHandler::source_id_geo_id_map_t local_source_id_geo_id_map = m_file_level_source_id_geo_id_map;
+  sid_handler.fetch_record_level_geo_id_info(record_group, local_source_id_geo_id_map);
+
+  // fetch the record-level source-id-to-path map
+  HDF5SourceIDHandler::source_id_path_map_t source_id_path_map;
+  sid_handler.fetch_source_id_path_info(record_group, source_id_path_map);
+
+  // fetch the record-level fragment-type-to-source-id map
+  HDF5SourceIDHandler::fragment_type_source_id_map_t fragment_type_source_id_map;
+  sid_handler.fetch_fragment_type_source_id_info(record_group, fragment_type_source_id_map);
+
+  // fetch the record-level subdetector-to-source-id map
+  HDF5SourceIDHandler::subdetector_source_id_map_t subdetector_source_id_map;
+  sid_handler.fetch_subdetector_source_id_info(record_group, subdetector_source_id_map);
+
+  // loop through the source-id-to-path map to create various lists of SourceIDs in the record
+  daqdataformats::SourceID rh_sid = sid_handler.fetch_record_header_source_id(record_group);
+  std::set<daqdataformats::SourceID> full_source_id_set;
+  std::set<daqdataformats::SourceID> fragment_source_id_set;
+  HDF5SourceIDHandler::subsystem_source_id_map_t subsystem_source_id_map;
+  for (auto const& source_id_path : source_id_path_map) {
+    full_source_id_set.insert(source_id_path.first);
+    if (source_id_path.first != rh_sid) {
+      fragment_source_id_set.insert(source_id_path.first);
+    }
+    HDF5SourceIDHandler::add_subsystem_source_id_to_map(
+      subsystem_source_id_map, source_id_path.first.subsystem, source_id_path.first);
+  }
+
+  // note that even if the "fetch" methods above fail to add anything to the specified
+  // maps, the maps will still be valid (though, possibly empty), and once we add them
+  // to the caches here, we will be assured that lookups from the caches will not fail.
+  m_source_id_cache[rid] = full_source_id_set;
+  m_record_header_source_id_cache[rid] = rh_sid;
+  m_fragment_source_id_cache[rid] = fragment_source_id_set;
+  m_source_id_geo_id_cache[rid] = local_source_id_geo_id_map;
+  m_source_id_path_cache[rid] = source_id_path_map;
+  m_subsystem_source_id_cache[rid] = subsystem_source_id_map;
+  m_fragment_type_source_id_cache[rid] = fragment_type_source_id_map;
+  m_subdetector_source_id_cache[rid] = subdetector_source_id_map;
+}
+
+/**
+ * @brief Return a vector of dataset names
+ */
+std::vector<std::string>
+HDF5RawDataFile::get_dataset_paths(std::string top_level_group_name)
+{
+  if (top_level_group_name.empty())
+    top_level_group_name = m_file_ptr->getPath();
+
+  // Vector containing the path list to the HDF5 datasets
+  std::vector<std::string> path_list;
+
+  HighFive::Group parent_group = m_file_ptr->getGroup(top_level_group_name);
+  if (!parent_group.isValid())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Invalid HDF5 Group: " << top_level_group_name;
+
+  explore_subgroup(parent_group, top_level_group_name, path_list);
+
+  return path_list;
+}
+
+/**
+ * @brief Return all of the record numbers in the file.
+ */
+HDF5RawDataFile::record_id_set // NOLINT(build/unsigned)
+HDF5RawDataFile::get_all_record_ids()
+{
+  if (!m_all_record_ids_in_file.empty())
+    return m_all_record_ids_in_file;
+
+  // records are at the top level
+
+  HighFive::Group parent_group = m_file_ptr->getGroup(m_file_ptr->getPath());
+
+  std::vector<std::string> childNames = parent_group.listObjectNames();
+  const std::string record_prefix = m_file_layout_ptr->get_record_name_prefix();
+  const size_t record_prefix_size = record_prefix.size();
+
+  for (auto const& name : childNames) {
+    auto loc = name.find(record_prefix);
+
+    if (loc == std::string::npos)
+      continue;
+
+    auto rec_num_string = name.substr(loc + record_prefix_size);
+
+    loc = rec_num_string.find(".");
+    if (loc == std::string::npos) {
+      m_all_record_ids_in_file.insert(std::make_pair(std::stoll(rec_num_string), 0));
+    } else {
+      auto seq_num_string = rec_num_string.substr(loc + 1);
+      rec_num_string.resize(loc); // remove anything from '.' onwards
+      m_all_record_ids_in_file.insert(std::make_pair(std::stoll(rec_num_string), std::stoi(seq_num_string)));
+    }
+
+  } // end loop over childNames
+
+  return m_all_record_ids_in_file;
+}
+
+std::set<uint64_t>
+HDF5RawDataFile::get_all_record_numbers() // NOLINT(build/unsigned)
+{
+  MF_LOG_WARNING("HDF5RawDataFile.cpp") << "Deprecated usage, get_all_record_numbers().  Use get_all_record_ids(),  which returns a record_number,sequence_number pair.";
+
+  std::set<uint64_t> record_numbers; // NOLINT(build/unsigned)
+  for (auto const& rid : get_all_record_ids())
+    record_numbers.insert(rid.first);
+
+  return record_numbers;
+}
+
+HDF5RawDataFile::record_id_set
+HDF5RawDataFile::get_all_trigger_record_ids()
+{
+  check_record_type("TriggerRecord");
+  return get_all_record_ids();
+}
+
+std::set<daqdataformats::trigger_number_t>
+HDF5RawDataFile::get_all_trigger_record_numbers()
+{
+  MF_LOG_WARNING("HDF5RawDataFile.cpp") << "Deprecated usage, get_all_trigger_record_numbers().  Use get_all_trigger_record_ids(),  which returns a record_number,sequence_number pair.";
+
+  return get_all_record_numbers();
+}
+
+HDF5RawDataFile::record_id_set
+HDF5RawDataFile::get_all_timeslice_ids()
+{
+  check_record_type("TimeSlice");
+  return get_all_record_ids();
+}
+
+std::set<daqdataformats::timeslice_number_t>
+HDF5RawDataFile::get_all_timeslice_numbers()
+{
+  check_record_type("TimeSlice");
+  return get_all_record_numbers();
+}
+
+/**
+ * @brief Return a vector of dataset names that correspond to record headers
+ */
+std::vector<std::string>
+HDF5RawDataFile::get_record_header_dataset_paths()
+{
+
+  std::vector<std::string> rec_paths;
+
+  if (get_version() >= 2) {
+    for (auto const& rec_id : get_all_record_ids())
+      rec_paths.push_back(get_record_header_dataset_path(rec_id));
+  } else {
+    for (auto const& path : get_dataset_paths()) {
+      if (path.find(m_file_layout_ptr->get_record_header_dataset_name()) != std::string::npos) {
+        rec_paths.push_back(path);
+      }
+    }
+  }
+
+  return rec_paths;
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_trigger_record_header_dataset_paths()
+{
+  check_record_type("TriggerRecord");
+  return get_record_header_dataset_paths();
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_timeslice_header_dataset_paths()
+{
+  check_record_type("TimeSlice");
+  return get_record_header_dataset_paths();
+}
+
+std::string
+HDF5RawDataFile::get_record_header_dataset_path(const record_id_t& rid)
+{
+  // this used to just call get_all_record_ids().find(rid) but the c14 compiler complained that the
+  // object backing it was temporary.  Create a local variable allrecids to store the record ids; shouldn't
+  // be too prohibitive in storage and it goes out of scope at the end of the method.  This pattern is repeated
+  // multiple times in this source file
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  if (get_version() <= 2) {
+    return (m_file_ptr->getPath() + m_file_layout_ptr->get_record_header_path(rid.first, rid.second));
+  } else {
+    daqdataformats::SourceID source_id = get_record_header_source_id(rid);
+    return m_source_id_path_cache[rid][source_id];
+  }
+}
+
+std::string
+HDF5RawDataFile::get_record_header_dataset_path(const uint64_t rec_num, // NOLINT (build/unsigned)
+                                                const daqdataformats::sequence_number_t seq_num)
+{
+  return get_record_header_dataset_path(std::make_pair(rec_num, seq_num));
+}
+
+std::string
+HDF5RawDataFile::get_trigger_record_header_dataset_path(const record_id_t& rid)
+{
+  check_record_type("TriggerRecord");
+  return get_record_header_dataset_path(rid);
+}
+
+std::string
+HDF5RawDataFile::get_trigger_record_header_dataset_path(const daqdataformats::trigger_number_t trig_num,
+                                                        const daqdataformats::sequence_number_t seq_num)
+{
+  check_record_type("TriggerRecord");
+  return get_record_header_dataset_path(trig_num, seq_num);
+}
+
+std::string
+HDF5RawDataFile::get_timeslice_header_dataset_path(const record_id_t& rid)
+{
+  check_record_type("TimeSlice");
+  return get_record_header_dataset_path(rid.first, 0);
+}
+
+std::string
+HDF5RawDataFile::get_timeslice_header_dataset_path(const daqdataformats::timeslice_number_t ts_num)
+{
+  check_record_type("TimeSlice");
+  return get_record_header_dataset_path(ts_num);
+}
+
+/**
+ * @brief Return a vector of dataset names that correspond to Fragemnts
+ * Note: this gets all datsets, and then removes those that look like TriggerRecordHeader ones
+ *       one could instead loop through all system types and ask for appropriate datsets in those
+ *       however, probably that's more time consuming
+ */
+std::vector<std::string>
+HDF5RawDataFile::get_all_fragment_dataset_paths()
+{
+  std::vector<std::string> frag_paths;
+
+  for (auto const& path : get_dataset_paths()) {
+    if (path.find(m_file_layout_ptr->get_record_header_dataset_name()) == std::string::npos)
+      frag_paths.push_back(path);
+  }
+
+  return frag_paths;
+}
+
+// get all fragment dataset paths for given record ID
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const record_id_t& rid)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  std::vector<std::string> frag_paths;
+  if (get_version() <= 2) {
+    std::string record_group_path =
+      m_file_ptr->getPath() + m_file_layout_ptr->get_record_number_string(rid.first, rid.second);
+
+    for (auto const& path : get_dataset_paths(record_group_path)) {
+      if (path.find(m_file_layout_ptr->get_record_header_dataset_name()) == std::string::npos)
+        frag_paths.push_back(path);
+    }
+  } else {
+    std::set<daqdataformats::SourceID> source_id_list = get_fragment_source_ids(rid);
+    for (auto const& source_id : source_id_list) {
+      frag_paths.push_back(m_source_id_path_cache[rid][source_id]);
+    }
+  }
+  return frag_paths;
+}
+
+// get all fragment dataset paths for given record ID
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const uint64_t rec_num, // NOLINT (build/unsigned)
+                                            const daqdataformats::sequence_number_t seq_num)
+{
+  return get_fragment_dataset_paths(std::make_pair(rec_num, seq_num));
+}
+
+// get all fragment dataset paths for a Subsystem
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const daqdataformats::SourceID::Subsystem subsystem)
+{
+  std::vector<std::string> frag_paths;
+  for (auto const& rid : get_all_record_ids()) {
+    if (get_version() <= 2) {
+      auto datasets = get_dataset_paths(m_file_ptr->getPath() +
+                                        m_file_layout_ptr->get_fragment_type_path(rid.first, rid.second, subsystem));
+      frag_paths.insert(frag_paths.end(), datasets.begin(), datasets.end());
+    } else {
+      std::set<daqdataformats::SourceID> source_id_list = get_source_ids_for_subsystem(rid, subsystem);
+      for (auto const& source_id : source_id_list) {
+        frag_paths.push_back(m_source_id_path_cache[rid][source_id]);
+      }
+    }
+  }
+  return frag_paths;
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const std::string& subsystem_name)
+{
+  daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::string_to_subsystem(subsystem_name);
+  return get_fragment_dataset_paths(subsystem);
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const record_id_t& rid, const daqdataformats::SourceID::Subsystem subsystem)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  if (get_version() <= 2) {
+    return get_dataset_paths(m_file_ptr->getPath() +
+                             m_file_layout_ptr->get_fragment_type_path(rid.first, rid.second, subsystem));
+  } else {
+    std::vector<std::string> frag_paths;
+    std::set<daqdataformats::SourceID> source_id_list = get_source_ids_for_subsystem(rid, subsystem);
+    for (auto const& source_id : source_id_list) {
+      frag_paths.push_back(m_source_id_path_cache[rid][source_id]);
+    }
+    return frag_paths;
+  }
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const record_id_t& rid, const std::string& subsystem_name)
+{
+  daqdataformats::SourceID::Subsystem subsystem = daqdataformats::SourceID::string_to_subsystem(subsystem_name);
+  return get_fragment_dataset_paths(rid, subsystem);
+}
+
+#if 0
+// get all fragment dataset paths for a SourceID
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const daqdataformats::SourceID& source_id)
+{
+  std::vector<std::string> frag_paths;
+
+  for (auto const& rid : get_all_record_ids())
+    frag_paths.push_back(m_file_ptr->getPath() +
+                         m_file_layout_ptr->get_fragment_path(rid.first, rid.second, source_id));
+
+  return frag_paths;
+}
+
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const daqdataformats::SourceID::Subsystem type,
+                                               const uint32_t id) // NOLINT(build/unsigned)
+{
+  return get_fragment_dataset_paths(daqdataformats::SourceID(type, source_id));
+}
+std::vector<std::string>
+HDF5RawDataFile::get_fragment_dataset_paths(const std::string& typestring,
+                                               const uint32_t id) // NOLINT(build/unsigned)
+{
+  return get_fragment_dataset_paths(
+    daqdataformats::SourceID(daqdataformats::SourceID::string_to_subsystem(typestring), source_id));
+}
+
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids(std::vector<std::string> const& frag_dataset_paths)
+{
+  std::set<daqdataformats::SourceID> source_ids;
+  std::vector<std::string> path_elements;
+  std::string s;
+  for (auto const& frag_dataset : frag_dataset_paths) {
+    path_elements.clear();
+    std::istringstream iss(frag_dataset);
+    while (std::getline(iss, s, '/')) {
+      if (s.size() > 0)
+        path_elements.push_back(s);
+    }
+    source_ids.insert(m_file_layout_ptr->get_source_id_from_path_elements(path_elements));
+  }
+
+  return source_ids;
+}
+#endif
+
+hdf5rawdatafile::SrcIDGeoIDMap
+HDF5RawDataFile::get_srcid_geoid_map() const {
+
+  return HDF5SourceIDHandler::rebuild_srcidgeoidmap(m_file_level_source_id_geo_id_map);
+}
+
+std::set<uint64_t> // NOLINT(build/unsigned)
+HDF5RawDataFile::get_all_geo_ids() const
+{
+  std::set<uint64_t> set_of_geo_ids;
+  // 13-Sep-2022, KAB
+  // It would be safer, but slower, to fetch all of the geo_ids from the 
+  // individual records, and we'll go with faster, for now.  If/when we
+  // change the way that we determine the file-level and record-level
+  // source_id-to-geo_id maps, we may need to change this code.
+  for (auto const& map_entry : m_file_level_source_id_geo_id_map) {
+    for (auto const& geo_id : map_entry.second) {
+      set_of_geo_ids.insert(geo_id);
+    }
+  }
+  return set_of_geo_ids;
+}
+
+std::set<uint64_t> // NOLINT(build/unsigned)
+HDF5RawDataFile::get_geo_ids(const record_id_t& rid)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  std::set<uint64_t> set_of_geo_ids;
+  for (auto const& map_entry : m_source_id_geo_id_cache[rid]) {
+    for (auto const& geo_id : map_entry.second) {
+      set_of_geo_ids.insert(geo_id);
+    }
+  }
+  return set_of_geo_ids;
+}
+
+std::set<uint64_t> // NOLINT(build/unsigned)
+HDF5RawDataFile::get_geo_ids_for_subdetector(const record_id_t& rid,
+                                             const detdataformats::DetID::Subdetector subdet)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  std::set<uint64_t> set_of_geo_ids;
+  for (auto const& map_entry : m_source_id_geo_id_cache[rid]) {
+    for (auto const& geo_id : map_entry.second) {
+
+      // auto geo_info = detchannelmaps::HardwareMapService::parse_geo_id(geo_id);
+      // had been a test on geo_info.det_id, but instead move the functionality here.
+
+      uint16_t geoinfodetid = 0xffff & geo_id;
+      if (geoinfodetid == static_cast<uint16_t>(subdet)) {
+        set_of_geo_ids.insert(geo_id);
+      }
+    }
+  }
+  return set_of_geo_ids;
+}
+
+
+// get all SourceIDs for given record ID
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids(const record_id_t& rid)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_source_id_cache[rid];
+}
+
+daqdataformats::SourceID
+HDF5RawDataFile::get_record_header_source_id(const record_id_t& rid)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_record_header_source_id_cache[rid];
+}
+
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_fragment_source_ids(const record_id_t& rid)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_fragment_source_id_cache[rid];
+}
+
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids_for_subsystem(const record_id_t& rid,
+                                              const daqdataformats::SourceID::Subsystem subsystem)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_subsystem_source_id_cache[rid][subsystem];
+}
+
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids_for_fragment_type(const record_id_t& rid, const daqdataformats::FragmentType frag_type)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_fragment_type_source_id_cache[rid][frag_type];
+}
+
+std::set<daqdataformats::SourceID>
+HDF5RawDataFile::get_source_ids_for_subdetector(const record_id_t& rid, const detdataformats::DetID::Subdetector subdet)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_subdetector_source_id_cache[rid][subdet];
+}
+
+std::unique_ptr<char[]>
+HDF5RawDataFile::get_dataset_raw_data(const std::string& dataset_path)
+{
+
+  HighFive::Group parent_group = m_file_ptr->getGroup("/");
+  HighFive::DataSet data_set = parent_group.getDataSet(dataset_path);
+
+  if (!data_set.isValid())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Invalid HDF5 Dataset: " << dataset_path << " " << get_file_name();
+
+  size_t data_size = data_set.getStorageSize();
+
+  auto membuffer = std::make_unique<char[]>(data_size);
+  data_set.read(membuffer.get());
+  return membuffer;
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const std::string& dataset_name)
+{
+  auto membuffer = get_dataset_raw_data(dataset_name);
+  auto frag_ptr = std::make_unique<daqdataformats::Fragment>(
+    membuffer.release(), dunedaq::daqdataformats::Fragment::BufferAdoptionMode::kTakeOverBuffer);
+  return frag_ptr;
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const record_id_t& rid, const daqdataformats::SourceID& source_id)
+{
+  if (get_version() < 2)
+    throw cet::exception("HDF5RawDataFile.cpp") << "Incompatible File Layout Version: " <<  get_version() << " 2 " << MAX_FILELAYOUT_VERSION;
+
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return get_frag_ptr(m_source_id_path_cache[rid][source_id]);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                              const daqdataformats::sequence_number_t seq_num,
+                              const daqdataformats::SourceID& source_id)
+{
+  record_id_t rid = std::make_pair(rec_num, seq_num);
+  return get_frag_ptr(rid, source_id);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const record_id_t& rid,
+                              const daqdataformats::SourceID::Subsystem type,
+                              const uint32_t id) // NOLINT(build/unsigned)
+{
+  daqdataformats::SourceID source_id(type, id);
+  return get_frag_ptr(rid, source_id);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                              const daqdataformats::sequence_number_t seq_num,
+                              const daqdataformats::SourceID::Subsystem type,
+                              const uint32_t id) // NOLINT(build/unsigned)
+{
+  record_id_t rid = std::make_pair(rec_num, seq_num);
+  daqdataformats::SourceID source_id(type, id);
+  return get_frag_ptr(rid, source_id);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const record_id_t& rid,
+                              const std::string& typestring,
+                              const uint32_t id) // NOLINT(build/unsigned)
+{
+  daqdataformats::SourceID source_id(daqdataformats::SourceID::string_to_subsystem(typestring), id);
+  return get_frag_ptr(rid, source_id);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                              const daqdataformats::sequence_number_t seq_num,
+                              const std::string& typestring,
+                              const uint32_t id) // NOLINT(build/unsigned)
+{
+  record_id_t rid = std::make_pair(rec_num, seq_num);
+  daqdataformats::SourceID source_id(daqdataformats::SourceID::string_to_subsystem(typestring), id);
+  return get_frag_ptr(rid, source_id);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const record_id_t& rid,
+                              const uint64_t geo_id) // NOLINT(build/unsigned)
+{
+  daqdataformats::SourceID sid = get_source_id_for_geo_id(rid, geo_id);
+  return get_frag_ptr(rid, sid);
+}
+
+std::unique_ptr<daqdataformats::Fragment>
+HDF5RawDataFile::get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                              const daqdataformats::sequence_number_t seq_num,
+                              const uint64_t geo_id) // NOLINT(build/unsigned)
+{
+  record_id_t rid = std::make_pair(rec_num, seq_num);
+  return get_frag_ptr(rid, geo_id);
+}
+
+std::unique_ptr<daqdataformats::TriggerRecordHeader>
+HDF5RawDataFile::get_trh_ptr(const std::string& dataset_name)
+{
+  auto membuffer = get_dataset_raw_data(dataset_name);
+  auto trh_ptr = std::make_unique<daqdataformats::TriggerRecordHeader>(membuffer.release(), true);
+  return trh_ptr;
+}
+
+std::unique_ptr<daqdataformats::TriggerRecordHeader>
+HDF5RawDataFile::get_trh_ptr(const record_id_t& rid)
+{
+  if (get_version() < 2)
+    throw cet::exception("HDF5RawDataFile.cpp") << "Incompatible File Layout Version: " <<  get_version() << " 2 " << MAX_FILELAYOUT_VERSION;
+
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  daqdataformats::SourceID rh_source_id = m_record_header_source_id_cache[rid];
+  return get_trh_ptr(m_source_id_path_cache[rid][rh_source_id]);
+}
+
+std::unique_ptr<daqdataformats::TimeSliceHeader>
+HDF5RawDataFile::get_tsh_ptr(const std::string& dataset_name)
+{
+  auto membuffer = get_dataset_raw_data(dataset_name);
+  auto tsh_ptr = std::make_unique<daqdataformats::TimeSliceHeader>(
+    *(reinterpret_cast<daqdataformats::TimeSliceHeader*>(membuffer.release()))); // NOLINT
+  return tsh_ptr;
+}
+
+std::unique_ptr<daqdataformats::TimeSliceHeader>
+HDF5RawDataFile::get_tsh_ptr(const record_id_t& rid)
+{
+  if (get_version() < 2)
+    throw cet::exception("HDF5RawDataFile.cpp") << "Incompatible File Layout Version: " <<  get_version() << " 2 " << MAX_FILELAYOUT_VERSION;
+
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  daqdataformats::SourceID rh_source_id = m_record_header_source_id_cache[rid];
+  return get_tsh_ptr(m_source_id_path_cache[rid][rh_source_id]);
+}
+
+daqdataformats::TriggerRecord
+HDF5RawDataFile::get_trigger_record(const record_id_t& rid)
+{
+  daqdataformats::TriggerRecord trigger_record(*get_trh_ptr(rid));
+  for (auto const& frag_path : get_fragment_dataset_paths(rid)) {
+    trigger_record.add_fragment(get_frag_ptr(frag_path));
+  }
+
+  return trigger_record;
+}
+
+daqdataformats::TimeSlice
+HDF5RawDataFile::get_timeslice(const daqdataformats::timeslice_number_t ts_num)
+{
+  daqdataformats::TimeSlice timeslice(*get_tsh_ptr(ts_num));
+  for (auto const& frag_path : get_fragment_dataset_paths(ts_num)) {
+    timeslice.add_fragment(get_frag_ptr(frag_path));
+  }
+
+  return timeslice;
+}
+
+std::vector<uint64_t> // NOLINT(build/unsigned)
+HDF5RawDataFile::get_geo_ids_for_source_id(const record_id_t& rid, const daqdataformats::SourceID& source_id)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  return m_source_id_geo_id_cache[rid][source_id];
+}
+
+daqdataformats::SourceID
+HDF5RawDataFile::get_source_id_for_geo_id(const record_id_t& rid,
+                                          const uint64_t requested_geo_id) // NOLINT(build/unsigned)
+{
+  auto allrecids = get_all_record_ids();
+  auto rec_id = allrecids.find(rid);
+  if (rec_id == allrecids.end())
+    throw cet::exception("HDF5RawDataFile.cpp") << "Record ID Not Found: " << rid.first << " " << rid.second;
+
+  add_record_level_info_to_caches_if_needed(rid);
+
+  // if we want to make this faster, we could build a reverse lookup cache in
+  // add_record_level_info_to_caches_if_needed() and just look up the requested geo_id here
+  for (auto const& map_entry : m_source_id_geo_id_cache[rid]) {
+    auto geoid_list = map_entry.second;
+    for (auto const& geoid_from_list : geoid_list) {
+      if (geoid_from_list == requested_geo_id) {
+        return map_entry.first;
+      }
+    }
+  }
+
+  daqdataformats::SourceID empty_sid;
+  return empty_sid;
+}
+
+} // namespace hdf5libs
+} // namespace dunedaq

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5RawDataFile.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5RawDataFile.hpp
@@ -1,0 +1,506 @@
+/**
+ * @file HDF5RawDataFile.hpp
+ *
+ * Class for reading out HDF5 files as
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef HDF5LIBS_INCLUDE_HDF5LIBS_HDF5RAWDATAFILE_HPP_
+#define HDF5LIBS_INCLUDE_HDF5LIBS_HDF5RAWDATAFILE_HPP_
+
+// DUNE-DAQ
+#include "HDF5FileLayout.hpp"
+#include "HDF5SourceIDHandler.hpp"
+#include "hdf5filelayout/Structs.hpp"
+
+#include "daqdataformats/v4_4_0/Fragment.hpp"
+#include "daqdataformats/v4_4_0/TimeSlice.hpp"
+#include "daqdataformats/v4_4_0/TriggerRecord.hpp"
+
+// External Packages
+#include <highfive/H5DataSet.hpp>
+#include <highfive/H5File.hpp>
+#include <highfive/H5Group.hpp>
+#include <highfive/H5Object.hpp>
+#include <nlohmann/json.hpp>
+
+// Offline includes
+
+#include "messagefacility/MessageLogger/MessageLogger.h"
+#include "cetlib_except/exception.h"
+
+// System
+#include <filesystem>
+#include <functional>
+#include <iostream>
+#include <map>
+#include <memory>
+#include <set>
+#include <string>
+#include <sys/statvfs.h>
+#include <utility>
+#include <variant>
+#include <vector>
+
+namespace dunedaq {
+
+namespace hdf5libs {
+
+/**
+ * @brief HDF5RawDataFile is the class responsible
+ * for interfacing the DAQ format with the HDF5 file format.
+ */
+class HDF5RawDataFile
+{
+
+public:
+  enum
+  {
+    TLVL_BASIC = 2,
+    TLVL_FILE_SIZE = 5
+  };
+
+  // define a record number type
+  // that is a pair of the trigger record or timeslice number and sequence number
+  typedef std::pair<uint64_t, daqdataformats::sequence_number_t> record_id_t; // NOLINT(build/unsigned)
+  typedef std::set<record_id_t, std::less<>> record_id_set;
+
+  // constructor for writing
+  HDF5RawDataFile(std::string file_name,
+                  daqdataformats::run_number_t run_number,
+                  size_t file_index,
+                  std::string application_name,
+                  const hdf5filelayout::FileLayoutParams& fl_params,
+                  hdf5rawdatafile::SrcIDGeoIDMap srcid_geoid_map,
+                  std::string inprogress_filename_suffix = ".writing",
+                  unsigned open_flags = HighFive::File::Create);
+
+  // constructor for reading
+  explicit HDF5RawDataFile(const std::string& file_name);
+
+  ~HDF5RawDataFile();
+
+  std::string get_file_name() const { return m_file_ptr->getName(); }
+
+  size_t get_recorded_size() const noexcept { return m_recorded_size; }
+
+  std::string get_record_type() const noexcept { return m_record_type; }
+
+  bool is_trigger_record_type() const noexcept { return m_record_type.compare("TriggerRecord") == 0; }
+  bool is_timeslice_type() const noexcept { return m_record_type.compare("TimeSlice") == 0; }
+
+  const HDF5FileLayout& get_file_layout() const { return *(m_file_layout_ptr.get()); }
+
+  uint32_t get_version() const // NOLINT(build/unsigned)
+  {
+    return m_file_layout_ptr->get_version();
+  }
+
+  // basic data writing methods
+public:
+  void write(const daqdataformats::TriggerRecord& tr);
+  void write(const daqdataformats::TimeSlice& ts);
+
+private:
+  HighFive::Group write(const daqdataformats::TriggerRecordHeader& trh,
+                        HDF5SourceIDHandler::source_id_path_map_t& path_map);
+  HighFive::Group write(const daqdataformats::TimeSliceHeader& tsh,
+                        HDF5SourceIDHandler::source_id_path_map_t& path_map);
+  void write(const daqdataformats::Fragment& frag, HDF5SourceIDHandler::source_id_path_map_t& path_map);
+
+public:
+  // attribute writers/getters
+  template<typename T>
+  void write_attribute(std::string name, T value);
+  template<typename T>
+  void write_attribute(HighFive::Group& grp, const std::string& name, T value);
+  template<typename T>
+  void write_attribute(HighFive::DataSet& dset, const std::string& name, T value);
+
+  std::vector<std::string> get_attribute_names();
+  template<typename T>
+  T get_attribute(const std::string& name);
+  template<typename T>
+  T get_attribute(const HighFive::Group& grp, const std::string& name);
+  template<typename T>
+  T get_attribute(const HighFive::DataSet& dset, std::string name);
+
+  std::vector<std::string> get_dataset_paths(std::string top_level_group_name = "");
+
+  record_id_set get_all_record_ids();
+  record_id_set get_all_trigger_record_ids();
+  record_id_set get_all_timeslice_ids();
+
+  std::set<uint64_t> get_all_record_numbers(); // NOLINT(build/unsigned)
+  std::set<daqdataformats::trigger_number_t> get_all_trigger_record_numbers();
+  std::set<daqdataformats::timeslice_number_t> get_all_timeslice_numbers();
+
+  std::vector<std::string> get_record_header_dataset_paths();
+  std::vector<std::string> get_trigger_record_header_dataset_paths();
+  std::vector<std::string> get_timeslice_header_dataset_paths();
+
+  std::string get_record_header_dataset_path(const record_id_t& rid);
+  std::string get_record_header_dataset_path(const uint64_t rec_num, // NOLINT (build/unsigned)
+                                             const daqdataformats::sequence_number_t seq_num = 0);
+  std::string get_trigger_record_header_dataset_path(const record_id_t& rid);
+  std::string get_trigger_record_header_dataset_path(const daqdataformats::trigger_number_t trig_num,
+                                                     const daqdataformats::sequence_number_t seq_num = 0);
+  std::string get_timeslice_header_dataset_path(const record_id_t& rid);
+  std::string get_timeslice_header_dataset_path(const daqdataformats::timeslice_number_t trig_num);
+
+  // get all fragment dataset paths
+  std::vector<std::string> get_all_fragment_dataset_paths();
+
+  // get all fragment dataset paths for given record ID
+  std::vector<std::string> get_fragment_dataset_paths(const record_id_t& rid);
+  std::vector<std::string> get_fragment_dataset_paths(const uint64_t rec_num, // NOLINT (build/unsigned)
+                                                      const daqdataformats::sequence_number_t seq_num = 0);
+
+  // get all fragment dataset paths for a Subsystem
+  std::vector<std::string> get_fragment_dataset_paths(const daqdataformats::SourceID::Subsystem subsystem);
+  std::vector<std::string> get_fragment_dataset_paths(const std::string& subsystem_name);
+
+  // get all fragment dataset paths for a record ID and Subsystem
+  std::vector<std::string> get_fragment_dataset_paths(const record_id_t& rid,
+                                                      const daqdataformats::SourceID::Subsystem subsystem);
+  std::vector<std::string> get_fragment_dataset_paths(const record_id_t& rid, const std::string& subsystem_name);
+
+#if 0
+  // get all fragment dataset paths for a SourceID
+  std::vector<std::string> get_fragment_dataset_paths(const daqdataformats::SourceID& source_id);
+  std::vector<std::string> get_fragment_dataset_paths(const daqdataformats::SourceID::Subsystem type,
+  const uint32_t id); // NOLINT(build/unsigned)
+  std::vector<std::string> get_fragment_dataset_paths(const std::string& typestring,
+  const uint32_t id); // NOLINT(build/unsigned)
+
+  // get a list of all the source ids from a list of fragment dataset paths
+  std::set<daqdataformats::SourceID> get_source_ids(std::vector<std::string> const& frag_dataset_paths);
+#endif
+
+  hdf5rawdatafile::SrcIDGeoIDMap get_srcid_geoid_map() const;
+  
+  //get a list of all the geo ids anywhere in the file
+  std::set<uint64_t> get_all_geo_ids() const; // NOLINT(build/unsigned)
+
+  //get GeoIDs in a record
+  std::set<uint64_t> get_geo_ids(const record_id_t& rid); // NOLINT(build/unsigned)
+  std::set<uint64_t> get_geo_ids(const uint64_t rec_num, //NOLINT(build/unsigned)
+                                 const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_geo_ids(std::make_pair(rec_num, seq_num));
+  }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const record_id_t& rid, // NOLINT(build/unsigned)
+                                                 const detdataformats::DetID::Subdetector subdet);
+  std::set<uint64_t> get_geo_ids_for_subdetector(const uint64_t rec_num, //NOLINT(build/unsigned)
+                                                 const daqdataformats::sequence_number_t seq_num,
+                                                 const detdataformats::DetID::Subdetector subdet)
+  {
+    return get_geo_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet);
+  }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const record_id_t& rid, // NOLINT(build/unsigned)
+                                                 const std::string& subdet_name)
+  {
+    detdataformats::DetID::Subdetector subdet = detdataformats::DetID::string_to_subdetector(subdet_name);
+    return get_geo_ids_for_subdetector(rid, subdet);
+  }
+  std::set<uint64_t> get_geo_ids_for_subdetector(const uint64_t rec_num, //NOLINT(build/unsigned)
+                                                 const daqdataformats::sequence_number_t seq_num,
+                                                 const std::string& subdet_name)
+  {
+    return get_geo_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet_name);
+  }
+
+  // get SourceIDs in a record
+  std::set<daqdataformats::SourceID> get_source_ids(const record_id_t& rid);
+  std::set<daqdataformats::SourceID> get_source_ids(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                    const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_source_ids(std::make_pair(rec_num, seq_num));
+  }
+
+  daqdataformats::SourceID get_record_header_source_id(const record_id_t& rid);
+  daqdataformats::SourceID get_record_header_source_id(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                       const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_record_header_source_id(std::make_pair(rec_num, seq_num));
+  }
+
+  std::set<daqdataformats::SourceID> get_fragment_source_ids(const record_id_t& rid);
+  std::set<daqdataformats::SourceID> get_fragment_source_ids(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                             const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_fragment_source_ids(std::make_pair(rec_num, seq_num));
+  }
+
+  // get SourceIDs for given subsystem in a record
+  std::set<daqdataformats::SourceID> get_source_ids_for_subsystem(const record_id_t& rid,
+                                                                  const daqdataformats::SourceID::Subsystem subsystem);
+  std::set<daqdataformats::SourceID> get_source_ids_for_subsystem(const record_id_t& rid,
+                                                                  const std::string& subsystem_name)
+  {
+    daqdataformats::SourceID::Subsystem subsys = daqdataformats::SourceID::string_to_subsystem(subsystem_name);
+    return get_source_ids_for_subsystem(rid, subsys);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_subsystem(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                  const daqdataformats::sequence_number_t seq_num,
+                                                                  const daqdataformats::SourceID::Subsystem subsystem)
+  {
+    return get_source_ids_for_subsystem(std::make_pair(rec_num, seq_num), subsystem);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_subsystem(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                  const daqdataformats::sequence_number_t seq_num,
+                                                                  const std::string& subsystem_name)
+  {
+    return get_source_ids_for_subsystem(std::make_pair(rec_num, seq_num), subsystem_name);
+  }
+
+  // get SourceIDs for given fragment type in a record
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragment_type(const record_id_t& rid,
+                                                                      const daqdataformats::FragmentType frag_type);
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragment_type(const record_id_t& rid,
+                                                                      const std::string& frag_type_name)
+  {
+    daqdataformats::FragmentType frag_type = daqdataformats::string_to_fragment_type(frag_type_name);
+    return get_source_ids_for_fragment_type(rid, frag_type);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragment_type(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                      const daqdataformats::sequence_number_t seq_num,
+                                                                      const daqdataformats::FragmentType frag_type)
+  {
+    return get_source_ids_for_fragment_type(std::make_pair(rec_num, seq_num), frag_type);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_fragment_type(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                      const daqdataformats::sequence_number_t seq_num,
+                                                                      const std::string& frag_type_name)
+  {
+    return get_source_ids_for_fragment_type(std::make_pair(rec_num, seq_num), frag_type_name);
+  }
+
+  // get SourceIDs for given subdetector in a record
+  std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const record_id_t& rid,
+                                                                    const detdataformats::DetID::Subdetector subdet);
+  std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const record_id_t& rid,
+                                                                    const std::string& subdet_name)
+  {
+    detdataformats::DetID::Subdetector subdet = detdataformats::DetID::string_to_subdetector(subdet_name);
+    return get_source_ids_for_subdetector(rid, subdet);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                    const daqdataformats::sequence_number_t seq_num,
+                                                                    const detdataformats::DetID::Subdetector subdet)
+  {
+    return get_source_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet);
+  }
+  std::set<daqdataformats::SourceID> get_source_ids_for_subdetector(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                                    const daqdataformats::sequence_number_t seq_num,
+                                                                    const std::string& subdet_name)
+  {
+    return get_source_ids_for_subdetector(std::make_pair(rec_num, seq_num), subdet_name);
+  }
+
+#if 0
+  // get SourceIDs for a system type
+  std::set<daqdataformats::SourceID> get_source_ids(const daqdataformats::SourceID::Subsystem type)
+  {
+    return get_source_ids(get_fragment_dataset_paths(type));
+  }
+  std::set<daqdataformats::SourceID> get_source_ids(const std::string& typestring)
+  {
+    return get_source_ids(get_fragment_dataset_paths(typestring));
+  }
+#endif
+
+  std::unique_ptr<char[]> get_dataset_raw_data(const std::string& dataset_path);
+
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const std::string& dataset_name);
+  std::unique_ptr<daqdataformats::TriggerRecordHeader> get_trh_ptr(const std::string& dataset_name);
+  std::unique_ptr<daqdataformats::TimeSliceHeader> get_tsh_ptr(const std::string& dataset_name);
+
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const record_id_t& rid,
+                                                         const daqdataformats::SourceID& source_id);
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                         const daqdataformats::sequence_number_t seq_num,
+                                                         const daqdataformats::SourceID& source_id);
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const record_id_t& rid,
+                                                         const daqdataformats::SourceID::Subsystem type,
+                                                         const uint32_t id);     // NOLINT(build/unsigned)
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                         const daqdataformats::sequence_number_t seq_num,
+                                                         const daqdataformats::SourceID::Subsystem type,
+                                                         const uint32_t id); // NOLINT(build/unsigned)
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const record_id_t& rid,
+                                                         const std::string& typestring,
+                                                         const uint32_t id);     // NOLINT(build/unsigned)
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                         const daqdataformats::sequence_number_t seq_num,
+                                                         const std::string& typestring,
+                                                         const uint32_t id); // NOLINT(build/unsigned)
+
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const record_id_t& rid,
+                                                         const uint64_t geo_id); // NOLINT(build/unsigned)
+  std::unique_ptr<daqdataformats::Fragment> get_frag_ptr(const uint64_t rec_num, // NOLINT(build/unsigned)
+                                                         const daqdataformats::sequence_number_t seq_num,
+                                                         const uint64_t geo_id); // NOLINT(build/unsigned)
+
+  std::unique_ptr<daqdataformats::TriggerRecordHeader> get_trh_ptr(const record_id_t& rid);
+  std::unique_ptr<daqdataformats::TriggerRecordHeader> get_trh_ptr(const daqdataformats::trigger_number_t trig_num,
+                                                                   const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_trh_ptr(std::make_pair(trig_num, seq_num));
+  }
+
+  std::unique_ptr<daqdataformats::TimeSliceHeader> get_tsh_ptr(const record_id_t& rid);
+  std::unique_ptr<daqdataformats::TimeSliceHeader> get_tsh_ptr(const daqdataformats::timeslice_number_t ts_num)
+  {
+    return get_tsh_ptr(std::make_pair(ts_num, 0));
+  }
+
+  daqdataformats::TriggerRecord get_trigger_record(const record_id_t& rid);
+  daqdataformats::TriggerRecord get_trigger_record(const daqdataformats::trigger_number_t trig_num,
+                                                   const daqdataformats::sequence_number_t seq_num = 0)
+  {
+    return get_trigger_record(std::make_pair(trig_num, seq_num));
+  }
+
+  daqdataformats::TimeSlice get_timeslice(const daqdataformats::timeslice_number_t ts_num);
+  daqdataformats::TimeSlice get_timeslice(const record_id_t& rid) { return get_timeslice(rid.first); }
+
+  std::vector<uint64_t> get_geo_ids_for_source_id(const record_id_t& rid, // NOLINT(build/unsigned)
+                                                  const daqdataformats::SourceID& source_id);
+
+  daqdataformats::SourceID get_source_id_for_geo_id(const record_id_t& rid,
+                                                    const uint64_t geo_id); // NOLINT(build/unsigned)
+
+private:
+  HDF5RawDataFile(const HDF5RawDataFile&) = delete;
+  HDF5RawDataFile& operator=(const HDF5RawDataFile&) = delete;
+  HDF5RawDataFile(HDF5RawDataFile&&) = delete;
+  HDF5RawDataFile& operator=(HDF5RawDataFile&&) = delete;
+
+  std::unique_ptr<HighFive::File> m_file_ptr;
+  std::unique_ptr<HDF5FileLayout> m_file_layout_ptr;
+  const std::string m_bare_file_name;
+  const unsigned m_open_flags;
+
+  // Total size of data being written
+  size_t m_recorded_size;
+  std::string m_record_type;
+
+  // file layout writing/reading
+  void write_file_layout();
+  void read_file_layout();
+  void check_file_layout();
+
+  // checking function
+  void check_record_type(std::string);
+
+  // writing to datasets
+  std::tuple<size_t, std::string, HighFive::Group> do_write(std::vector<std::string> const&, const char*, size_t);
+  
+  // unpacking groups when reading
+  void explore_subgroup(const HighFive::Group& parent_group,
+                        std::string relative_path,
+                        std::vector<std::string>& path_list);
+
+  // adds record-level information to caches, if needed
+  void add_record_level_info_to_caches_if_needed(record_id_t rid);
+
+  // caches of full-file and record-specific information
+  record_id_set m_all_record_ids_in_file;
+  HDF5SourceIDHandler::source_id_geo_id_map_t m_file_level_source_id_geo_id_map;
+  std::map<record_id_t, std::set<daqdataformats::SourceID>> m_source_id_cache;
+  std::map<record_id_t, daqdataformats::SourceID> m_record_header_source_id_cache;
+  std::map<record_id_t, std::set<daqdataformats::SourceID>> m_fragment_source_id_cache;
+  std::map<record_id_t, HDF5SourceIDHandler::source_id_path_map_t> m_source_id_path_cache;
+  std::map<record_id_t, HDF5SourceIDHandler::source_id_geo_id_map_t> m_source_id_geo_id_cache;
+  std::map<record_id_t, HDF5SourceIDHandler::subsystem_source_id_map_t> m_subsystem_source_id_cache;
+  std::map<record_id_t, HDF5SourceIDHandler::fragment_type_source_id_map_t> m_fragment_type_source_id_cache;
+  std::map<record_id_t, HDF5SourceIDHandler::subdetector_source_id_map_t> m_subdetector_source_id_cache;
+};
+
+// HDF5RawDataFile attribute writers/getters definitions
+template<typename T>
+void
+HDF5RawDataFile::write_attribute(std::string name, T value)
+{
+  if (!m_file_ptr->hasAttribute(name))
+    m_file_ptr->createAttribute(name, value);
+  else
+    MF_LOG_WARNING("HDF5RawDataFile.hpp: ") << "HDF5 attribute exists: " << name;
+}
+
+template<typename T>
+void
+HDF5RawDataFile::write_attribute(HighFive::Group& grp, const std::string& name, T value)
+{
+  if (!(grp.hasAttribute(name)))
+    grp.createAttribute<T>(name, value);
+  else
+    MF_LOG_WARNING("HDF5RawDataFile.hpp: ") << "HDF5 attribute exists: " << name;
+}
+
+template<typename T>
+void
+HDF5RawDataFile::write_attribute(HighFive::DataSet& dset, const std::string& name, T value)
+{
+  if (!dset.hasAttribute(name))
+    dset.createAttribute<T>(name, value);
+  else
+    MF_LOG_WARNING("HDF5RawDataFile.hpp: ") << "HDF5 attribute exists: " << name;
+}
+
+std::vector<std::string> HDF5RawDataFile::get_attribute_names()
+{
+  return m_file_ptr->listAttributeNames();
+}
+  
+template<typename T>
+T
+HDF5RawDataFile::get_attribute(const std::string& name)
+{
+  if (!m_file_ptr->hasAttribute(name)) {
+    throw cet::exception("HDFRawDataFile.h") << "Invalid HDF5 Attribute: " << name;
+  }
+  auto attr = m_file_ptr->getAttribute(name);
+  T value;
+  attr.read(value);
+  return value;
+}
+
+template<typename T>
+T
+HDF5RawDataFile::get_attribute(const HighFive::Group& grp, const std::string& name)
+{
+  if (!(grp.hasAttribute(name))) {
+    throw cet::exception("HDFRawDataFile.h") << "Invalid HDF5 Attribute: " << name;
+  }
+  auto attr = grp.getAttribute(name);
+  T value;
+  attr.read(value);
+  return value;
+}
+
+template<typename T>
+T
+HDF5RawDataFile::get_attribute(const HighFive::DataSet& dset, std::string name)
+{
+  if (!dset.hasAttribute(name)) {
+    throw cet::exception("HDFRawDataFile.h") << "Invalid HDF5 Attribute: " << name;
+  }
+  auto attr = dset.getAttribute(name);
+  T value;
+  attr.read(value);
+  return value;
+}
+
+} // namespace hdf5libs
+} // namespace dunedaq
+
+#endif // HDF5LIBS_INCLUDE_HDF5LIBS_HDF5RAWDATAFILE_HPP_
+
+// Local Variables:
+// c-basic-offset: 2
+// End:

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5SourceIDHandler.cpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5SourceIDHandler.cpp
@@ -1,0 +1,406 @@
+/**
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ *
+ * Modified April 23, 2024 by Tom Junk for dune-daq v4.4.0
+ */
+
+#include "HDF5SourceIDHandler.hpp"
+#include "hdf5sourceidmaps/Nljs.hpp"
+#include "hdf5rawdatafile/Nljs.hpp"
+
+
+namespace dunedaq {
+namespace hdf5libs {
+
+void 
+HDF5SourceIDHandler::populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap  src_id_geo_id_mp_struct,
+                                  source_id_geo_id_map_t& source_id_geo_id_map)
+{
+
+  for( auto const& entry : src_id_geo_id_mp_struct ) {
+    daqdataformats::SourceID source_id(daqdataformats::SourceID::Subsystem::kDetectorReadout, entry.src_id);
+    // FIXME: replace with a proper coder/decoder
+    uint64_t geoid = (static_cast<uint64_t>(entry.geo_id.stream_id) << 48) | (static_cast<uint64_t>(entry.geo_id.slot_id) << 32) | (static_cast<uint64_t>(entry.geo_id.crate_id) << 16) | entry.geo_id.det_id;
+    add_source_id_geo_id_to_map(source_id_geo_id_map, source_id, geoid);
+  }
+}
+
+hdf5rawdatafile::SrcIDGeoIDMap
+HDF5SourceIDHandler::rebuild_srcidgeoidmap(const source_id_geo_id_map_t& the_map) {
+
+  hdf5rawdatafile::SrcIDGeoIDMap m;
+  for( const auto& [sid, geoids] : the_map ) {
+      // There could be more than one, but we don't want to think about that
+      uint64_t geoid = *geoids.begin();
+      m.emplace_back(hdf5rawdatafile::SrcIDGeoIDEntry{
+        sid.id, 
+        hdf5rawdatafile::GeoID{
+          (int) ((geoid >> 0) & 0xff),  //det_id
+          (int) ((geoid >> 16) & 0xff), //crate_id
+          (int) ((geoid >> 32) & 0xff), //slot_id
+          (int) ((geoid >> 48) & 0xff), //stream_id
+        }
+      }
+    );
+  } 
+
+  return m;
+}
+  
+void
+HDF5SourceIDHandler::store_file_level_geo_id_info(HighFive::File& h5_file, const source_id_geo_id_map_t& the_map)
+{
+  write_attribute(h5_file, "source_id_geo_id_map", get_json_string(the_map));
+}
+
+void
+HDF5SourceIDHandler::store_record_header_source_id(HighFive::Group& record_group,
+                                                   const daqdataformats::SourceID& source_id)
+{
+  write_attribute(record_group, "record_header_source_id", get_json_string(source_id));
+}
+
+void
+HDF5SourceIDHandler::store_record_level_path_info(HighFive::Group& record_group, const source_id_path_map_t& the_map)
+{
+  write_attribute(record_group, "source_id_path_map", get_json_string(the_map));
+}
+
+void
+HDF5SourceIDHandler::store_record_level_fragment_type_map(HighFive::Group& record_group,
+                                                          const fragment_type_source_id_map_t& the_map)
+{
+  write_attribute(record_group, "fragment_type_source_id_map", get_json_string(the_map));
+}
+
+void
+HDF5SourceIDHandler::store_record_level_subdetector_map(HighFive::Group& record_group,
+                                                        const subdetector_source_id_map_t& the_map)
+{
+  write_attribute(record_group, "subdetector_source_id_map", get_json_string(the_map));
+}
+
+HDF5SourceIDHandler::HDF5SourceIDHandler(const uint32_t version) // NOLINT(build/unsigned)
+  : m_version(version)
+{}
+
+void
+HDF5SourceIDHandler::fetch_file_level_geo_id_info(const HighFive::File& h5_file,
+                                                  source_id_geo_id_map_t& source_id_geo_id_map)
+{
+  if (m_version >= 3) {
+    try {
+      std::string map_string = get_attribute<HighFive::File, std::string>(h5_file, "source_id_geo_id_map");
+      parse_json_string(map_string, source_id_geo_id_map);
+    } catch (...) {
+    }
+  }
+}
+
+void
+HDF5SourceIDHandler::fetch_record_level_geo_id_info(const HighFive::Group& /*record_group*/,
+                                                    source_id_geo_id_map_t& /*source_id_geo_id_map*/)
+{
+  // In versions 3 and 4, there is no record-level geo_id information stored in the file
+  if (m_version >= 3) {
+    return;
+  }
+}
+
+daqdataformats::SourceID
+HDF5SourceIDHandler::fetch_record_header_source_id(const HighFive::Group& record_group)
+{
+  daqdataformats::SourceID source_id;
+  if (m_version >= 3) {
+    try {
+      std::string sid_string = get_attribute<HighFive::Group, std::string>(record_group, "record_header_source_id");
+      parse_json_string(sid_string, source_id);
+    } catch (...) {
+    }
+  }
+  return source_id;
+}
+
+void
+HDF5SourceIDHandler::fetch_source_id_path_info(const HighFive::Group& record_group,
+                                               source_id_path_map_t& source_id_path_map)
+{
+  if (m_version >= 3) {
+    try {
+      std::string map_string = get_attribute<HighFive::Group, std::string>(record_group, "source_id_path_map");
+      parse_json_string(map_string, source_id_path_map);
+    } catch (...) {
+    }
+  }
+}
+
+void
+HDF5SourceIDHandler::fetch_fragment_type_source_id_info(const HighFive::Group& record_group,
+                                                        fragment_type_source_id_map_t& fragment_type_source_id_map)
+{
+  if (m_version >= 3) {
+    try {
+      std::string map_string = get_attribute<HighFive::Group, std::string>(record_group, "fragment_type_source_id_map");
+      parse_json_string(map_string, fragment_type_source_id_map);
+    } catch (...) {
+    }
+  }
+}
+
+void
+HDF5SourceIDHandler::fetch_subdetector_source_id_info(const HighFive::Group& record_group,
+                                                      subdetector_source_id_map_t& subdetector_source_id_map)
+{
+  if (m_version >= 3) {
+    try {
+      std::string map_string = get_attribute<HighFive::Group, std::string>(record_group, "subdetector_source_id_map");
+      parse_json_string(map_string, subdetector_source_id_map);
+    } catch (...) {
+    }
+  }
+}
+
+void
+HDF5SourceIDHandler::add_source_id_path_to_map(source_id_path_map_t& source_id_path_map,
+                                               const daqdataformats::SourceID& source_id,
+                                               const std::string& hdf5_path)
+{
+  source_id_path_map[source_id] = hdf5_path;
+}
+
+void
+HDF5SourceIDHandler::add_source_id_geo_id_to_map(source_id_geo_id_map_t& source_id_geo_id_map,
+                                                 const daqdataformats::SourceID& source_id,
+                                                 uint64_t geo_id) // NOLINT(build/unsigned)
+{
+  if (source_id_geo_id_map.count(source_id) == 0) {
+    std::vector<uint64_t> tmp_vec; // NOLINT(build/unsigned)
+    tmp_vec.push_back(geo_id);
+    source_id_geo_id_map[source_id] = tmp_vec;
+  } else {
+    source_id_geo_id_map[source_id].push_back(geo_id);
+  }
+}
+
+void
+HDF5SourceIDHandler::add_fragment_type_source_id_to_map(fragment_type_source_id_map_t& fragment_type_source_id_map,
+                                                        const daqdataformats::FragmentType fragment_type,
+                                                        const daqdataformats::SourceID& source_id)
+{
+  if (fragment_type_source_id_map.count(fragment_type) == 0) {
+    std::set<daqdataformats::SourceID> tmp_set;
+    tmp_set.insert(source_id);
+    fragment_type_source_id_map[fragment_type] = tmp_set;
+  } else {
+    fragment_type_source_id_map[fragment_type].insert(source_id);
+  }
+}
+
+void
+HDF5SourceIDHandler::add_subdetector_source_id_to_map(subdetector_source_id_map_t& subdetector_source_id_map,
+                                                      const detdataformats::DetID::Subdetector subdetector,
+                                                      const daqdataformats::SourceID& source_id)
+{
+  if (subdetector_source_id_map.count(subdetector) == 0) {
+    std::set<daqdataformats::SourceID> tmp_set;
+    tmp_set.insert(source_id);
+    subdetector_source_id_map[subdetector] = tmp_set;
+  } else {
+    subdetector_source_id_map[subdetector].insert(source_id);
+  }
+}
+
+void
+HDF5SourceIDHandler::add_subsystem_source_id_to_map(subsystem_source_id_map_t& subsystem_source_id_map,
+                                                    const daqdataformats::SourceID::Subsystem subsystem,
+                                                    const daqdataformats::SourceID& source_id)
+{
+  if (subsystem_source_id_map.count(subsystem) == 0) {
+    std::set<daqdataformats::SourceID> tmp_set;
+    tmp_set.insert(source_id);
+    subsystem_source_id_map[subsystem] = tmp_set;
+  } else {
+    subsystem_source_id_map[subsystem].insert(source_id);
+  }
+}
+
+std::string
+HDF5SourceIDHandler::get_json_string(const daqdataformats::SourceID& source_id)
+{
+  hdf5sourceidmaps::SourceID json_struct;
+  json_struct.subsys = static_cast<uint32_t>(source_id.subsystem); // NOLINT(build/unsigned)
+  json_struct.id = source_id.id;
+  hdf5sourceidmaps::data_t json_tmp_data;
+  hdf5sourceidmaps::to_json(json_tmp_data, json_struct);
+  return json_tmp_data.dump();
+}
+
+std::string
+HDF5SourceIDHandler::get_json_string(const HDF5SourceIDHandler::source_id_path_map_t& the_map)
+{
+  hdf5sourceidmaps::SourceIDPathMap json_struct;
+  for (auto const& map_element : the_map) {
+    hdf5sourceidmaps::SourceIDPathPair json_element;
+    json_element.subsys = static_cast<uint32_t>(map_element.first.subsystem); // NOLINT(build/unsigned)
+    json_element.id = map_element.first.id;
+    json_element.path = map_element.second;
+    json_struct.map_entries.push_back(json_element);
+  }
+  hdf5sourceidmaps::data_t json_tmp_data;
+  hdf5sourceidmaps::to_json(json_tmp_data, json_struct);
+  return json_tmp_data.dump();
+}
+
+std::string
+HDF5SourceIDHandler::get_json_string(const HDF5SourceIDHandler::source_id_geo_id_map_t& the_map)
+{
+  hdf5sourceidmaps::SourceIDGeoIDMap json_struct;
+  for (auto const& map_element : the_map) {
+    hdf5sourceidmaps::GeoIDList json_geo_id_list;
+    for (auto const& geo_id_from_map : map_element.second) {
+      json_geo_id_list.push_back(geo_id_from_map);
+    }
+    hdf5sourceidmaps::SourceIDGeoIDPair json_element;
+    json_element.subsys = static_cast<uint32_t>(map_element.first.subsystem); // NOLINT(build/unsigned)
+    json_element.id = map_element.first.id;
+    json_element.geoids = json_geo_id_list;
+    json_struct.map_entries.push_back(json_element);
+  }
+  hdf5sourceidmaps::data_t json_tmp_data;
+  hdf5sourceidmaps::to_json(json_tmp_data, json_struct);
+  return json_tmp_data.dump();
+}
+
+std::string
+HDF5SourceIDHandler::get_json_string(const HDF5SourceIDHandler::fragment_type_source_id_map_t& the_map)
+{
+  hdf5sourceidmaps::FragmentTypeSourceIDMap json_struct;
+  for (auto const& map_element : the_map) {
+    hdf5sourceidmaps::SourceIDList json_source_id_list;
+    for (auto const& source_id_from_map : map_element.second) {
+      hdf5sourceidmaps::SourceID json_source_id;
+      json_source_id.subsys = static_cast<uint32_t>(source_id_from_map.subsystem); // NOLINT(build/unsigned)
+      json_source_id.id = source_id_from_map.id;
+      json_source_id_list.push_back(json_source_id);
+    }
+    hdf5sourceidmaps::FragmentTypeSourceIDPair json_element;
+    json_element.fragment_type = static_cast<uint32_t>(map_element.first);
+    json_element.sourceids = json_source_id_list;
+    json_struct.map_entries.push_back(json_element);
+  }
+  hdf5sourceidmaps::data_t json_tmp_data;
+  hdf5sourceidmaps::to_json(json_tmp_data, json_struct);
+  return json_tmp_data.dump();
+}
+
+std::string
+HDF5SourceIDHandler::get_json_string(const HDF5SourceIDHandler::subdetector_source_id_map_t& the_map)
+{
+  hdf5sourceidmaps::SubdetectorSourceIDMap json_struct;
+  for (auto const& map_element : the_map) {
+    hdf5sourceidmaps::SourceIDList json_source_id_list;
+    for (auto const& source_id_from_map : map_element.second) {
+      hdf5sourceidmaps::SourceID json_source_id;
+      json_source_id.subsys = static_cast<uint32_t>(source_id_from_map.subsystem); // NOLINT(build/unsigned)
+      json_source_id.id = source_id_from_map.id;
+      json_source_id_list.push_back(json_source_id);
+    }
+    hdf5sourceidmaps::SubdetectorSourceIDPair json_element;
+    json_element.subdetector = static_cast<uint32_t>(map_element.first);
+    json_element.sourceids = json_source_id_list;
+    json_struct.map_entries.push_back(json_element);
+  }
+  hdf5sourceidmaps::data_t json_tmp_data;
+  hdf5sourceidmaps::to_json(json_tmp_data, json_struct);
+  return json_tmp_data.dump();
+}
+
+void
+HDF5SourceIDHandler::parse_json_string(const std::string& json_string, daqdataformats::SourceID& source_id)
+{
+  hdf5sourceidmaps::SourceID json_struct;
+  hdf5sourceidmaps::data_t json_tmp_data = nlohmann::json::parse(json_string);
+  hdf5sourceidmaps::from_json(json_tmp_data, json_struct);
+  daqdataformats::SourceID::Subsystem subsys = static_cast<daqdataformats::SourceID::Subsystem>(json_struct.subsys);
+  daqdataformats::SourceID::ID_t id = static_cast<daqdataformats::SourceID::ID_t>(json_struct.id);
+  source_id.subsystem = subsys;
+  source_id.id = id;
+}
+
+void
+HDF5SourceIDHandler::parse_json_string(const std::string& json_string, source_id_path_map_t& source_id_path_map)
+{
+  hdf5sourceidmaps::SourceIDPathMap json_struct;
+  hdf5sourceidmaps::data_t json_tmp_data = nlohmann::json::parse(json_string);
+  hdf5sourceidmaps::from_json(json_tmp_data, json_struct);
+  for (auto const& json_element : json_struct.map_entries) {
+    daqdataformats::SourceID::Subsystem subsys = static_cast<daqdataformats::SourceID::Subsystem>(json_element.subsys);
+    daqdataformats::SourceID::ID_t id = static_cast<daqdataformats::SourceID::ID_t>(json_element.id);
+    daqdataformats::SourceID source_id(subsys, id);
+    source_id_path_map[source_id] = json_element.path;
+  }
+}
+
+void
+HDF5SourceIDHandler::parse_json_string(const std::string& json_string, source_id_geo_id_map_t& source_id_geo_id_map)
+{
+  hdf5sourceidmaps::SourceIDGeoIDMap json_struct;
+  hdf5sourceidmaps::data_t json_tmp_data = nlohmann::json::parse(json_string);
+  hdf5sourceidmaps::from_json(json_tmp_data, json_struct);
+  for (auto const& json_element : json_struct.map_entries) {
+    daqdataformats::SourceID::Subsystem subsys = static_cast<daqdataformats::SourceID::Subsystem>(json_element.subsys);
+    daqdataformats::SourceID::ID_t id = static_cast<daqdataformats::SourceID::ID_t>(json_element.id);
+    daqdataformats::SourceID source_id(subsys, id);
+    std::vector<uint64_t> local_geo_id_list; // NOLINT(build/unsigned)
+    hdf5sourceidmaps::GeoIDList json_geo_id_list = json_element.geoids;
+    for (hdf5sourceidmaps::GeoIDValue json_geo_id_value : json_geo_id_list) {
+      local_geo_id_list.push_back(json_geo_id_value);
+    }
+    source_id_geo_id_map[source_id] = local_geo_id_list;
+  }
+}
+
+void
+HDF5SourceIDHandler::parse_json_string(const std::string& json_string, fragment_type_source_id_map_t& fragment_type_source_id_map)
+{
+  hdf5sourceidmaps::FragmentTypeSourceIDMap json_struct;
+  hdf5sourceidmaps::data_t json_tmp_data = nlohmann::json::parse(json_string);
+  hdf5sourceidmaps::from_json(json_tmp_data, json_struct);
+  for (auto const& json_element : json_struct.map_entries) {
+    daqdataformats::FragmentType fragment_type = static_cast<daqdataformats::FragmentType>(json_element.fragment_type);
+    std::set<daqdataformats::SourceID> local_source_id_list;
+    hdf5sourceidmaps::SourceIDList json_source_id_list = json_element.sourceids;
+    for (hdf5sourceidmaps::SourceID json_source_id : json_source_id_list) {
+      daqdataformats::SourceID::Subsystem subsys = static_cast<daqdataformats::SourceID::Subsystem>(json_source_id.subsys);
+      daqdataformats::SourceID::ID_t id = static_cast<daqdataformats::SourceID::ID_t>(json_source_id.id);
+      daqdataformats::SourceID source_id(subsys, id);
+      local_source_id_list.insert(source_id);
+    }
+    fragment_type_source_id_map[fragment_type] = local_source_id_list;
+  }
+}
+
+void
+HDF5SourceIDHandler::parse_json_string(const std::string& json_string, subdetector_source_id_map_t& subdetector_source_id_map)
+{
+  hdf5sourceidmaps::SubdetectorSourceIDMap json_struct;
+  hdf5sourceidmaps::data_t json_tmp_data = nlohmann::json::parse(json_string);
+  hdf5sourceidmaps::from_json(json_tmp_data, json_struct);
+  for (auto const& json_element : json_struct.map_entries) {
+    detdataformats::DetID::Subdetector subdetector = static_cast<detdataformats::DetID::Subdetector>(json_element.subdetector);
+    std::set<daqdataformats::SourceID> local_source_id_list;
+    hdf5sourceidmaps::SourceIDList json_source_id_list = json_element.sourceids;
+    for (hdf5sourceidmaps::SourceID json_source_id : json_source_id_list) {
+      daqdataformats::SourceID::Subsystem subsys = static_cast<daqdataformats::SourceID::Subsystem>(json_source_id.subsys);
+      daqdataformats::SourceID::ID_t id = static_cast<daqdataformats::SourceID::ID_t>(json_source_id.id);
+      daqdataformats::SourceID source_id(subsys, id);
+      local_source_id_list.insert(source_id);
+    }
+    subdetector_source_id_map[subdetector] = local_source_id_list;
+  }
+}
+
+} // namespace hdf5libs
+} // namespace dunedaq

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5SourceIDHandler.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/HDF5SourceIDHandler.hpp
@@ -1,0 +1,258 @@
+/**
+ * @file HDF5SourceIDHandler.hpp
+ *
+ * Collection of routines for translating SourceID-related quantities
+ * from string formats to in-memory representations and back.
+ *
+ * This is part of the DUNE DAQ Application Framework, copyright 2020.
+ * Licensing/copyright details are in the COPYING file that you should have
+ * received with this code.
+ */
+
+#ifndef HDF5LIBS_INCLUDE_HDF5LIBS_HDF5SOURCEIDHANDLER_HPP_
+#define HDF5LIBS_INCLUDE_HDF5LIBS_HDF5SOURCEIDHANDLER_HPP_
+
+#include "daqdataformats/v4_4_0/Fragment.hpp"
+#include "daqdataformats/v4_4_0/SourceID.hpp"
+#include "hdf5rawdatafile/Structs.hpp"
+#include "detdataformats/DetID.hpp"
+
+#include <highfive/H5File.hpp>
+#include <highfive/H5Group.hpp>
+
+#include <cstdint>
+#include <map>
+#include <set>
+#include <string>
+#include <vector>
+
+namespace dunedaq {
+namespace hdf5libs {
+
+/**
+ * At the moment, this class is designed to handle different versions of
+ * translation (to/from strings) when *reading* data.  For writing data,
+ * the interface is currently designed to only support the current version
+ * of the translation.  If we ever decide to add support for writing of
+ * different versions, then the 'store' methods would become non-static.
+ */
+
+class HDF5SourceIDHandler
+{
+public:
+  typedef std::map<daqdataformats::SourceID, std::string> source_id_path_map_t;
+  typedef std::map<daqdataformats::SourceID, std::vector<uint64_t>> source_id_geo_id_map_t; // NOLINT(build/unsigned)
+  typedef std::map<daqdataformats::SourceID::Subsystem, std::set<daqdataformats::SourceID>> subsystem_source_id_map_t;
+  typedef std::map<daqdataformats::FragmentType, std::set<daqdataformats::SourceID>> fragment_type_source_id_map_t;
+  typedef std::map<detdataformats::DetID::Subdetector, std::set<daqdataformats::SourceID>> subdetector_source_id_map_t;
+
+  /**
+   * Populates the specified source_id_geo_id map with information contained in the
+   * specified Hardware Map.
+   */
+  static void populate_source_id_geo_id_map(dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDMap  src_id_geo_id_mp_struct,
+                                            source_id_geo_id_map_t& the_map);
+
+  /**
+   * Reconstruct the SrcIDGeoIDMap
+  */
+  static hdf5rawdatafile::SrcIDGeoIDMap rebuild_srcidgeoidmap(const source_id_geo_id_map_t& the_map);
+  /**
+   * Stores the map from SourceID to GeoID in the specified HighFive::File.
+   */
+  static void store_file_level_geo_id_info(HighFive::File& h5_file, const source_id_geo_id_map_t& the_map);
+
+  /**
+   * Stores the SourceID of the record header DataSet in the specified HighFive::Group.
+   */
+  static void store_record_header_source_id(HighFive::Group& record_group, const daqdataformats::SourceID& source_id);
+
+  /**
+   * Stores the map from SourceID to HDF5 Path in the specified HighFive::Group.
+   */
+  static void store_record_level_path_info(HighFive::Group& record_group, const source_id_path_map_t& the_map);
+
+  /**
+   * Stores the map from FragmentType to SourceID in the specified HighFive::Group.
+   */
+  static void store_record_level_fragment_type_map(HighFive::Group& record_group,
+                                                   const fragment_type_source_id_map_t& the_map);
+
+  /**
+   * Stores the map from DetID::Subdetector to SourceID in the specified HighFive::Group.
+   */
+  static void store_record_level_subdetector_map(HighFive::Group& record_group,
+                                                 const subdetector_source_id_map_t& the_map);
+
+  /**
+   * @brief Constructor.
+   */
+  explicit HDF5SourceIDHandler(const uint32_t version); // NOLINT(build/unsigned)
+
+  /**
+   * Adds entries to the specified SourceID-to-GeoID map using information
+   * stored at the file level in the specified HighFive::File.
+   */
+  void fetch_file_level_geo_id_info(const HighFive::File& h5_file, source_id_geo_id_map_t& the_map);
+
+  /**
+   * Adds entries to the specified SourceID-to-GeoID map using information
+   * stored at the record level in the specified HighFive::Group.
+   */
+  void fetch_record_level_geo_id_info(const HighFive::Group& record_group, source_id_geo_id_map_t& the_map);
+
+  /**
+   * Fetches the record header SourceID using information
+   * stored at the record level in the specified HighFive::Group.
+   */
+  daqdataformats::SourceID fetch_record_header_source_id(const HighFive::Group& record_group);
+
+  /**
+   * Adds entries to the specified SourceID-to-HDF5-Path map using information
+   * stored at the record level in the specified HighFive::Group.
+   */
+  void fetch_source_id_path_info(const HighFive::Group& record_group, source_id_path_map_t& the_map);
+
+  /**
+   * Adds entries to the specified FragmentType-to-SourceID map using information
+   * stored at the record level in the specified HighFive::Group.
+   */
+  void fetch_fragment_type_source_id_info(const HighFive::Group& record_group, fragment_type_source_id_map_t& the_map);
+
+  /**
+   * Adds entries to the specified Subdetector-to-SourceID map using information
+   * stored at the record level in the specified HighFive::Group.
+   */
+  void fetch_subdetector_source_id_info(const HighFive::Group& record_group, subdetector_source_id_map_t& the_map);
+
+  /**
+   * Adds the specified SourceID and HDF5 Path to the specified source_id_path map.
+   */
+  static void add_source_id_path_to_map(source_id_path_map_t& source_id_path_map,
+                                        const daqdataformats::SourceID& source_id,
+                                        const std::string& hdf5_path);
+
+  /**
+   * Adds the specified SourceID and GeoID list to the specified source_id_geo_id map.
+   */
+  static void add_source_id_geo_id_to_map(source_id_geo_id_map_t& source_id_geo_id_map,
+                                          const daqdataformats::SourceID& source_id,
+                                          uint64_t geo_id); // NOLINT(build/unsigned)
+
+  /**
+   * Adds the specified FragmentType and SourceId to the specified fragment_type_source_id map.
+   */
+  static void add_fragment_type_source_id_to_map(fragment_type_source_id_map_t& fragment_type_source_id_map,
+                                                 const daqdataformats::FragmentType fragment_type,
+                                                 const daqdataformats::SourceID& source_id);
+
+  /**
+   * Adds the specified Subdetector and SourceId to the specified subdetector_source_id map.
+   */
+  static void add_subdetector_source_id_to_map(subdetector_source_id_map_t& subdetector_source_id_map,
+                                               const detdataformats::DetID::Subdetector subdetector,
+                                               const daqdataformats::SourceID& source_id);
+
+  /**
+   * Adds the specified Subsystem and SourceId to the specified subsystem_source_id map.
+   */
+  static void add_subsystem_source_id_to_map(subsystem_source_id_map_t& subsystem_source_id_map,
+                                             const daqdataformats::SourceID::Subsystem subsystem,
+                                             const daqdataformats::SourceID& source_id);
+
+private:
+  /**
+   * @brief version number
+   */
+  uint32_t m_version; // NOLINT(build/unsigned)
+
+  /**
+   * Produces the JSON string that corresponds to the specified source_id
+   */
+  static std::string get_json_string(const daqdataformats::SourceID& source_id);
+
+  /**
+   * Produces the JSON string that corresponds to the specified source_id_path map
+   */
+  static std::string get_json_string(const source_id_path_map_t& source_id_path_map);
+
+  /**
+   * Produces the JSON string that corresponds to the specified source_id_geo_id map
+   */
+  static std::string get_json_string(const source_id_geo_id_map_t& source_id_geo_id_map);
+
+  /**
+   * Produces the JSON string that corresponds to the specified fragment_type_source_id map
+   */
+  static std::string get_json_string(const fragment_type_source_id_map_t& fragment_type_source_id_map);
+
+  /**
+   * Produces the JSON string that corresponds to the specified subdetector_source_id map
+   */
+  static std::string get_json_string(const subdetector_source_id_map_t& subdetector_source_id_map);
+
+  /**
+   * Parses the specified JSON string into the specified source_id
+   */
+  static void parse_json_string(const std::string& json_string, daqdataformats::SourceID& source_id);
+
+  /**
+   * Parses the specified JSON string into the specified source_id_path map
+   */
+  static void parse_json_string(const std::string& json_string, source_id_path_map_t& source_id_path_map);
+
+  /**
+   * Parses the specified JSON string into the specified source_id_geo_id map
+   */
+  static void parse_json_string(const std::string& json_string, source_id_geo_id_map_t& source_id_geo_id_map);
+
+  /**
+   * Parses the specified JSON string into the specified fragment_type_source_id_map
+   */
+  static void parse_json_string(const std::string& json_string, fragment_type_source_id_map_t& fragment_type_source_id_map);
+
+  /**
+   * Parses the specified JSON string into the specified subdetector_source_id_map
+   */
+  static void parse_json_string(const std::string& json_string, subdetector_source_id_map_t& subdetector_source_id_map);
+
+  /**
+   * Writes the specified attribute name and value to the specified HightFive File or Group.
+   */
+  template<typename C, typename T>
+  static void write_attribute(HighFive::AnnotateTraits<C>& h5annt, const std::string& name, T value);
+
+  /**
+   * Fetches the attribute with the specified name from the specified HightFive File or Group.
+   */
+  template<typename C, typename T>
+  static T get_attribute(const HighFive::AnnotateTraits<C>& h5annt, const std::string& name);
+};
+
+template<typename C, typename T>
+void
+HDF5SourceIDHandler::write_attribute(HighFive::AnnotateTraits<C>& h5annt, const std::string& name, T value)
+{
+  if (!(h5annt.hasAttribute(name)))
+    h5annt.createAttribute(name, value);
+  // else
+  //   ers::warning(HDF5AttributeExists(ERS_HERE, name));
+}
+
+template<typename C, typename T>
+T
+HDF5SourceIDHandler::get_attribute(const HighFive::AnnotateTraits<C>& h5annt, const std::string& name)
+{
+  // if (!h5annt.hasAttribute(name)) {
+  //   throw InvalidHDF5Attribute(ERS_HERE, name);
+  // }
+  auto attr = h5annt.getAttribute(name);
+  T value;
+  attr.read(value);
+  return value;
+}
+
+} // namespace hdf5libs
+} // namespace dunedaq
+
+#endif // HDF5LIBS_INCLUDE_HDF5LIBS_HDF5SOURCEIDHANDLER_HPP_

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/CMakeLists.txt
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_headers()

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/Nljs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/Nljs.hpp
@@ -1,0 +1,67 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5filelayout to be serialized via nlohmann::json.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_NLJS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_NLJS_HPP
+
+// My structs
+#include "Structs.hpp"
+
+
+#include <nlohmann/json.hpp>
+
+namespace dunedaq::hdf5libs::hdf5filelayout {
+
+    using data_t = nlohmann::json;
+    
+    inline void to_json(data_t& j, const PathParams& obj) {
+        j["detector_group_type"] = obj.detector_group_type;
+        j["detector_group_name"] = obj.detector_group_name;
+        j["element_name_prefix"] = obj.element_name_prefix;
+        j["digits_for_element_number"] = obj.digits_for_element_number;
+    }
+    
+    inline void from_json(const data_t& j, PathParams& obj) {
+        if (j.contains("detector_group_type"))
+            j.at("detector_group_type").get_to(obj.detector_group_type);    
+        if (j.contains("detector_group_name"))
+            j.at("detector_group_name").get_to(obj.detector_group_name);    
+        if (j.contains("element_name_prefix"))
+            j.at("element_name_prefix").get_to(obj.element_name_prefix);    
+        if (j.contains("digits_for_element_number"))
+            j.at("digits_for_element_number").get_to(obj.digits_for_element_number);    
+    }
+    
+    inline void to_json(data_t& j, const FileLayoutParams& obj) {
+        j["record_name_prefix"] = obj.record_name_prefix;
+        j["digits_for_record_number"] = obj.digits_for_record_number;
+        j["digits_for_sequence_number"] = obj.digits_for_sequence_number;
+        j["record_header_dataset_name"] = obj.record_header_dataset_name;
+        j["raw_data_group_name"] = obj.raw_data_group_name;
+        j["view_group_name"] = obj.view_group_name;
+        j["path_param_list"] = obj.path_param_list;
+    }
+    
+    inline void from_json(const data_t& j, FileLayoutParams& obj) {
+        if (j.contains("record_name_prefix"))
+            j.at("record_name_prefix").get_to(obj.record_name_prefix);    
+        if (j.contains("digits_for_record_number"))
+            j.at("digits_for_record_number").get_to(obj.digits_for_record_number);    
+        if (j.contains("digits_for_sequence_number"))
+            j.at("digits_for_sequence_number").get_to(obj.digits_for_sequence_number);    
+        if (j.contains("record_header_dataset_name"))
+            j.at("record_header_dataset_name").get_to(obj.record_header_dataset_name);    
+        if (j.contains("raw_data_group_name"))
+            j.at("raw_data_group_name").get_to(obj.raw_data_group_name);    
+        if (j.contains("view_group_name"))
+            j.at("view_group_name").get_to(obj.view_group_name);    
+        if (j.contains("path_param_list"))
+            j.at("path_param_list").get_to(obj.path_param_list);    
+    }
+    
+} // namespace dunedaq::hdf5libs::hdf5filelayout
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_NLJS_HPP

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/Structs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5filelayout/Structs.hpp
@@ -1,0 +1,83 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5filelayout.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_STRUCTS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_STRUCTS_HPP
+
+#include <cstdint>
+
+#include <vector>
+#include <string>
+
+namespace dunedaq::hdf5libs::hdf5filelayout {
+
+    // @brief A count of not too many things
+    using Count = int32_t;
+
+
+    // @brief A float number of 4 bytes
+    using Factor = float;
+
+
+    // @brief A string used in the hdf5 configuration
+    using HDFString = std::string;
+
+    // @brief Parameters for the HDF5 Group and DataSet names
+    struct PathParams 
+    {
+
+        // @brief The special keyword that identifies this entry (e.g. "TPC", "PDS", "TPC_TP", etc.)
+        HDFString detector_group_type = "unspecified";
+
+        // @brief The detector name that should be used inside the HDF5 file
+        HDFString detector_group_name = "unspecified";
+
+        // @brief Prefix for the element name
+        HDFString element_name_prefix = "Element";
+
+        // @brief Number of digits to use for the element ID number inside the HDF5 file
+        Count digits_for_element_number = 5;
+    };
+
+    // @brief List of subdetector path parameters
+    using PathParamList = std::vector<dunedaq::hdf5libs::hdf5filelayout::PathParams>;
+
+    // @brief Parameters for the layout of Groups and DataSets within the HDF5 file
+    struct FileLayoutParams 
+    {
+
+        // @brief Prefix for the record name
+        HDFString record_name_prefix = "TriggerRecord";
+
+        // @brief Number of digits to use for the record number in the record name inside the HDF5 file
+        Count digits_for_record_number = 6;
+
+        // @brief Number of digits to use for the sequence number in the TriggerRecord name inside the HDF5 file
+        Count digits_for_sequence_number = 4;
+
+        // @brief Dataset name for the record header
+        HDFString record_header_dataset_name = "TriggerRecordHeader";
+
+        // @brief Group name to use for raw data
+        HDFString raw_data_group_name = "RawData";
+
+        // @brief Group name to use for views of the raw data
+        HDFString view_group_name = "Views";
+
+        // @brief 
+        PathParamList path_param_list = {};
+    };
+
+    // @brief Parameter that can be used to enable or disable functionality
+    using Flag = bool;
+
+    // @brief A count of very many things
+    using Size = uint64_t; // NOLINT
+
+
+} // namespace dunedaq::hdf5libs::hdf5filelayout
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5FILELAYOUT_STRUCTS_HPP

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/CMakeLists.txt
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_headers()

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/Nljs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/Nljs.hpp
@@ -1,0 +1,51 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5rawdatafile to be serialized via nlohmann::json.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP
+
+// My structs
+#include "Structs.hpp"
+
+#include <nlohmann/json.hpp>
+
+namespace dunedaq::hdf5libs::hdf5rawdatafile {
+
+    using data_t = nlohmann::json;
+    
+    inline void to_json(data_t& j, const GeoID& obj) {
+        j["det_id"] = obj.det_id;
+        j["crate_id"] = obj.crate_id;
+        j["slot_id"] = obj.slot_id;
+        j["stream_id"] = obj.stream_id;
+    }
+    
+    inline void from_json(const data_t& j, GeoID& obj) {
+        if (j.contains("det_id"))
+            j.at("det_id").get_to(obj.det_id);    
+        if (j.contains("crate_id"))
+            j.at("crate_id").get_to(obj.crate_id);    
+        if (j.contains("slot_id"))
+            j.at("slot_id").get_to(obj.slot_id);    
+        if (j.contains("stream_id"))
+            j.at("stream_id").get_to(obj.stream_id);    
+    }
+    
+    inline void to_json(data_t& j, const SrcIDGeoIDEntry& obj) {
+        j["src_id"] = obj.src_id;
+        j["geo_id"] = obj.geo_id;
+    }
+    
+    inline void from_json(const data_t& j, SrcIDGeoIDEntry& obj) {
+        if (j.contains("src_id"))
+            j.at("src_id").get_to(obj.src_id);    
+        if (j.contains("geo_id"))
+            j.at("geo_id").get_to(obj.geo_id);    
+    }
+    
+} // namespace dunedaq::hdf5libs::hdf5rawdatafile
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_NLJS_HPP

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/Structs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5rawdatafile/Structs.hpp
@@ -1,0 +1,60 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5rawdatafile.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP
+
+#include <cstdint>
+
+#include <vector>
+
+namespace dunedaq::hdf5libs::hdf5rawdatafile {
+
+    // @brief A count of not too many things
+    using Count = int32_t;
+
+
+    // @brief Parameter that can be used to enable or disable functionality
+    using Flag = bool;
+
+    // @brief Geographic ID structure
+    struct GeoID 
+    {
+
+        // @brief Detector ID
+        Count det_id = 0;
+
+        // @brief Crate ID
+        Count crate_id = 0;
+
+        // @brief Slot ID
+        Count slot_id = 0;
+
+        // @brief Stream ID
+        Count stream_id = 0;
+    };
+
+    // @brief A count of very many things
+    using Size = uint64_t; // NOLINT
+
+
+    // @brief SourceID GeoID Map entry
+    struct SrcIDGeoIDEntry 
+    {
+
+        // @brief Source ID
+        Size src_id = 0;
+
+        // @brief Geo ID
+        GeoID geo_id = {0, 0, 0, 0};
+    };
+
+    // @brief SourceID to GeoID map
+    using SrcIDGeoIDMap = std::vector<dunedaq::hdf5libs::hdf5rawdatafile::SrcIDGeoIDEntry>;
+
+} // namespace dunedaq::hdf5libs::hdf5rawdatafile
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5RAWDATAFILE_STRUCTS_HPP

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/CMakeLists.txt
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/CMakeLists.txt
@@ -1,0 +1,1 @@
+install_headers()

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/Nljs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/Nljs.hpp
@@ -1,0 +1,124 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains functions struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5sourceidmaps to be serialized via nlohmann::json.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_NLJS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_NLJS_HPP
+
+// My structs
+#include "Structs.hpp"
+
+
+#include <nlohmann/json.hpp>
+
+namespace dunedaq::hdf5libs::hdf5sourceidmaps {
+
+    using data_t = nlohmann::json;
+    
+    inline void to_json(data_t& j, const SourceID& obj) {
+        j["subsys"] = obj.subsys;
+        j["id"] = obj.id;
+    }
+    
+    inline void from_json(const data_t& j, SourceID& obj) {
+        if (j.contains("subsys"))
+            j.at("subsys").get_to(obj.subsys);    
+        if (j.contains("id"))
+            j.at("id").get_to(obj.id);    
+    }
+    
+    inline void to_json(data_t& j, const FragmentTypeSourceIDPair& obj) {
+        j["fragment_type"] = obj.fragment_type;
+        j["sourceids"] = obj.sourceids;
+    }
+    
+    inline void from_json(const data_t& j, FragmentTypeSourceIDPair& obj) {
+        if (j.contains("fragment_type"))
+            j.at("fragment_type").get_to(obj.fragment_type);    
+        if (j.contains("sourceids"))
+            j.at("sourceids").get_to(obj.sourceids);    
+    }
+    
+    inline void to_json(data_t& j, const FragmentTypeSourceIDMap& obj) {
+        j["map_entries"] = obj.map_entries;
+    }
+    
+    inline void from_json(const data_t& j, FragmentTypeSourceIDMap& obj) {
+        if (j.contains("map_entries"))
+            j.at("map_entries").get_to(obj.map_entries);    
+    }
+    
+    inline void to_json(data_t& j, const SourceIDGeoIDPair& obj) {
+        j["subsys"] = obj.subsys;
+        j["id"] = obj.id;
+        j["geoids"] = obj.geoids;
+    }
+    
+    inline void from_json(const data_t& j, SourceIDGeoIDPair& obj) {
+        if (j.contains("subsys"))
+            j.at("subsys").get_to(obj.subsys);    
+        if (j.contains("id"))
+            j.at("id").get_to(obj.id);    
+        if (j.contains("geoids"))
+            j.at("geoids").get_to(obj.geoids);    
+    }
+    
+    inline void to_json(data_t& j, const SourceIDPathPair& obj) {
+        j["subsys"] = obj.subsys;
+        j["id"] = obj.id;
+        j["path"] = obj.path;
+    }
+    
+    inline void from_json(const data_t& j, SourceIDPathPair& obj) {
+        if (j.contains("subsys"))
+            j.at("subsys").get_to(obj.subsys);    
+        if (j.contains("id"))
+            j.at("id").get_to(obj.id);    
+        if (j.contains("path"))
+            j.at("path").get_to(obj.path);    
+    }
+    
+    inline void to_json(data_t& j, const SourceIDGeoIDMap& obj) {
+        j["map_entries"] = obj.map_entries;
+    }
+    
+    inline void from_json(const data_t& j, SourceIDGeoIDMap& obj) {
+        if (j.contains("map_entries"))
+            j.at("map_entries").get_to(obj.map_entries);    
+    }
+    
+    inline void to_json(data_t& j, const SourceIDPathMap& obj) {
+        j["map_entries"] = obj.map_entries;
+    }
+    
+    inline void from_json(const data_t& j, SourceIDPathMap& obj) {
+        if (j.contains("map_entries"))
+            j.at("map_entries").get_to(obj.map_entries);    
+    }
+    
+    inline void to_json(data_t& j, const SubdetectorSourceIDPair& obj) {
+        j["subdetector"] = obj.subdetector;
+        j["sourceids"] = obj.sourceids;
+    }
+    
+    inline void from_json(const data_t& j, SubdetectorSourceIDPair& obj) {
+        if (j.contains("subdetector"))
+            j.at("subdetector").get_to(obj.subdetector);    
+        if (j.contains("sourceids"))
+            j.at("sourceids").get_to(obj.sourceids);    
+    }
+    
+    inline void to_json(data_t& j, const SubdetectorSourceIDMap& obj) {
+        j["map_entries"] = obj.map_entries;
+    }
+    
+    inline void from_json(const data_t& j, SubdetectorSourceIDMap& obj) {
+        if (j.contains("map_entries"))
+            j.at("map_entries").get_to(obj.map_entries);    
+    }
+    
+} // namespace dunedaq::hdf5libs::hdf5sourceidmaps
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_NLJS_HPP

--- a/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/Structs.hpp
+++ b/Prototypes/TOAD/RawDecoding/dunedaqhdf5utils3/hdf5sourceidmaps/Structs.hpp
@@ -1,0 +1,141 @@
+/*
+ * This file is 100% generated.  Any manual edits will likely be lost.
+ *
+ * This contains struct and other type definitions for shema in 
+ * namespace dunedaq::hdf5libs::hdf5sourceidmaps.
+ */
+#ifndef DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_STRUCTS_HPP
+#define DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_STRUCTS_HPP
+
+#include <cstdint>
+
+#include <vector>
+#include <string>
+
+namespace dunedaq::hdf5libs::hdf5sourceidmaps {
+
+    // @brief Reasonably sized number
+    using NumericValue = uint32_t; // NOLINT
+
+
+    // @brief A single SourceID
+    struct SourceID 
+    {
+
+        // @brief SourceID subsystem
+        NumericValue subsys = 0;
+
+        // @brief SourceID ID
+        NumericValue id = 0;
+    };
+
+    // @brief List of SourceIDs
+    using SourceIDList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::SourceID>;
+
+    // @brief A single FragmentType-to-SourceID map entry
+    struct FragmentTypeSourceIDPair 
+    {
+
+        // @brief FragmentType
+        NumericValue fragment_type = 0;
+
+        // @brief List of SourceIDs for a given FragmentType
+        SourceIDList sourceids = {};
+    };
+
+    // @brief List of FragmentType to SourceID map entries
+    using FragmentTypeMapEntryList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::FragmentTypeSourceIDPair>;
+
+    // @brief Information that is needed to build up the map of FragmentTypes to SourceIDs
+    struct FragmentTypeSourceIDMap 
+    {
+
+        // @brief The list of entries in the map
+        FragmentTypeMapEntryList map_entries = {};
+    };
+
+    // @brief 64-bit number
+    using GeoIDValue = uint64_t; // NOLINT
+
+
+    // @brief List of GeoIDs
+    using GeoIDList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::GeoIDValue>;
+
+    // @brief A single SourceID-to-GeoID map entry
+    struct SourceIDGeoIDPair 
+    {
+
+        // @brief SourceID subsystem
+        NumericValue subsys = 0;
+
+        // @brief SourceID ID
+        NumericValue id = 0;
+
+        // @brief List of GeoIDs contained within the SourceID
+        GeoIDList geoids = {};
+    };
+
+    // @brief List of SourceID to GeoID map entries
+    using GeoIDMapEntryList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::SourceIDGeoIDPair>;
+
+    // @brief A string representing an HDF5 path
+    using PathString = std::string;
+
+    // @brief A single SourceID-to-HDF5-path map entry
+    struct SourceIDPathPair 
+    {
+
+        // @brief SourceID subsystem
+        NumericValue subsys = 0;
+
+        // @brief SourceID ID
+        NumericValue id = 0;
+
+        // @brief Path for the DataSet in the HDF5 file
+        PathString path = "";
+    };
+
+    // @brief List of SourceID to HDF5 path map entries
+    using PathMapEntryList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::SourceIDPathPair>;
+
+    // @brief Information that is needed to build up the map of SourceIDs to GeoIDs
+    struct SourceIDGeoIDMap 
+    {
+
+        // @brief The list of entries in the map
+        GeoIDMapEntryList map_entries = {};
+    };
+
+    // @brief Information that is needed to build up the map of SourceIDs to HDF5 DataSet paths
+    struct SourceIDPathMap 
+    {
+
+        // @brief The list of entries in the map
+        PathMapEntryList map_entries = {};
+    };
+
+    // @brief A single Subdetector-to-SourceID map entry
+    struct SubdetectorSourceIDPair 
+    {
+
+        // @brief DetID::Subdetector
+        NumericValue subdetector = 0;
+
+        // @brief List of SourceIDs for a given Subdetector
+        SourceIDList sourceids = {};
+    };
+
+    // @brief List of Subdetector to SourceID map entries
+    using SubdetectorMapEntryList = std::vector<dunedaq::hdf5libs::hdf5sourceidmaps::SubdetectorSourceIDPair>;
+
+    // @brief Information that is needed to build up the map of Subdetectors to SourceIDs
+    struct SubdetectorSourceIDMap 
+    {
+
+        // @brief The list of entries in the map
+        SubdetectorMapEntryList map_entries = {};
+    };
+
+} // namespace dunedaq::hdf5libs::hdf5sourceidmaps
+
+#endif // DUNEDAQ_HDF5LIBS_HDF5SOURCEIDMAPS_STRUCTS_HPP

--- a/Prototypes/TOAD/RawDecoding/runTOADRawDecoder3.fcl
+++ b/Prototypes/TOAD/RawDecoding/runTOADRawDecoder3.fcl
@@ -1,0 +1,42 @@
+#include "TOADInput3.fcl"
+
+services:
+{
+  TimeTracker:  {}
+  TFileService: 
+  {
+    fileName: "TOADRawDecoderTFile.root"
+  } 
+  TOADChannelMapService: 
+   {
+     FileName: "TOADChannelMap.txt"
+   }
+}
+
+physics:
+{
+# empty path for now -- the input source does all the work
+  producers:
+  {
+  }
+
+  produce: [  ] 
+  output: [ out1 ]
+  trigger_paths : [ produce ]
+  end_paths: [ output ]
+} 	     
+
+outputs:
+{
+  out1:
+  {
+    compressionLevel: 1
+    module_type: RootOutput
+    fileName: "%ifb_decode.root"
+  }
+}
+
+source: @local::TOADRawInput3SourceDefaults
+
+process_name: runTOADRawDecoder3
+

--- a/ups/product_deps
+++ b/ups/product_deps
@@ -36,8 +36,8 @@ duneutil        v09_79_00d02
 pandora         v03_16_00h
 edepsim         v3_2_0c
 garana          v00_03_00
-dunedetdataformats  v4_1_0
-dunedaqdataformats  v4_0_0
+dunedetdataformats  v4_4_0
+dunedaqdataformats  v4_4_0
 nlohmann_json       v3_10_4_1
 highfive            v2_4_1_2
 cetbuildtools	v8_20_00	-	only_for_build


### PR DESCRIPTION
This is a port of the DUNE-DAQ HDF5 utilities to read data written with DUNE-DAQ release 4.4.0, following the procedure used for ProtoDUNE-HD.  The issue is that the data formats  have changed, specifically the size of the trigger record header.  Reading HDF5 files written with DUNE-DAQ 4.4.0 with older DUNE-DAQ code causes misaligned reads.  At least for PDHD, we wanted to preserve the ability to read old data and new data, and since the DAQ header files had changed but their names and the classes in them had not, we needed to duplicate code that included these headers, or rewrite it to handle both.  I chose the duplication path.  So this means that there is now a TOADInput3_source that uses the new dunedaqhdf5utils3 code.  Reading old files is still supported, but adding features to the readers should be done on the new input source with the 3 in it, unless you really need new features added to reading old files.