### PR TITLE
add pressure to detector info, standard and TOAD, and add it to a linear expansion of density(T,P)

### DIFF
--- a/DetectorInfo/DetectorProperties.fcl
+++ b/DetectorInfo/DetectorProperties.fcl
@@ -6,6 +6,7 @@ standard_detproperties:
 
  # Drift properties
  Temperature:           294.26          # Kelvin  (70F)
+ Pressure:              10.0            # bar
  Efield:                [0.5,0.5,0.5 ]  # kV/cm -- three wire planes in larsoft -- fix for ALICE anode
  Electronlifetime:      3e6             # microseconds
  DriftVelocity:         3.011           # in cm/us
@@ -26,6 +27,7 @@ standard_detproperties_toad:
 
  # Drift properties
  Temperature:           294.26          # Kelvin  (70F)
+ Pressure:              10.0            # bar
  Efield:                [0.5,0.5,0.5 ]  # kV/cm -- three wire planes in larsoft -- fix for ALICE anode
  Electronlifetime:      3e6             # microseconds
  DriftVelocity:         3.011           # in cm/us

--- a/DetectorInfo/DetectorProperties.h
+++ b/DetectorInfo/DetectorProperties.h
@@ -51,18 +51,21 @@ namespace gar {
 
       virtual double DriftVelocity(double efield=0.,
                                    double temperature=0.,
+				   double pressure=0.,
                                    bool   cmPerns=true) const = 0;
 
       virtual double ElectronLifetime() const = 0;
 
       /**
-       * @brief Returns argon density at a given temperature
+       * @brief Returns argon density at a given temperature and pressure
        * @param temperature the temperature in kelvin
+       * @param pressure is the pressure in bar
        * @return argon density in g/cm^3
        */
-      virtual double Density(double temperature) const = 0;
+      virtual double Density(double temperature, double pressure) const = 0;
       virtual double Temperature() const = 0;
-
+      virtual double Pressure() const = 0;
+      
       /**
        * @brief Restricted mean energy loss (@f$ dE/dx @f$)
        * @param mom  momentum of incident particle [GeV/c]
@@ -87,7 +90,7 @@ namespace gar {
                               double mass)                 const = 0;
 
         /// Returns argon density at the temperature from Temperature()
-      virtual double Density() const { return Density(Temperature()); }
+      virtual double Density() const { return Density(Temperature(), Pressure()); }
 
       virtual double       SamplingRate()                  const = 0;
       virtual double       ElectronsToADC()                const = 0;

--- a/DetectorInfo/DetectorPropertiesStandard.cxx
+++ b/DetectorInfo/DetectorPropertiesStandard.cxx
@@ -124,6 +124,7 @@ namespace gar {
       fEfield                     = config.Efield();
       fElectronlifetime           = config.Electronlifetime();
       fTemperature                = config.Temperature();
+      fPressure                   = config.Pressure();
       fDriftVelocity              = config.DriftVelocity();
       fElectronsToADC             = config.ElectronsToADC();
       fNumberTimeSamples          = config.NumberTimeSamples();
@@ -135,6 +136,8 @@ namespace gar {
       fSternheimerParameters.cbar = config.SternheimerCbar();
 
       CalculateXTicksParams();
+
+      //std::cout << "density check: " << Density() << std::endl;
 
     } // DetectorPropertiesStandard::Configure()
 
@@ -186,14 +189,24 @@ namespace gar {
 
 
       //------------------------------------------------
-    double DetectorPropertiesStandard::Density(double temperature) const
+    double DetectorPropertiesStandard::Density(double temperature, double pressure) const
     {
+      // Temperature in K, Pressure in bar
+      // density is in grams per cubic centimeter
+      
       // Default temperature use internal value.
       if(temperature == 0.)
         temperature = Temperature();
 
-      double density = -0.00615*temperature + 1.928;
+      if(pressure == 0.)
+	pressure = Pressure();
 
+      // linear expansion around 294 K, 10 bar
+      
+      double density = 0.01645 + 0.00167678*(pressure - 10.0) - 0.00005828*(temperature - 294.0);
+
+      // std::cout << "temp: " << temperature << " pressure: " << pressure << " density: " << density << std::endl;
+      
       return density;
     } // DetectorPropertiesStandard::Density()
 
@@ -291,6 +304,7 @@ namespace gar {
     //------------------------------------------------------------------------------------//
     double DetectorPropertiesStandard::DriftVelocity(double efield,
                                                      double temperature,
+						     double pressure,
                                                      bool   cmPerns) const
     {
 
@@ -314,9 +328,13 @@ namespace gar {
       if(temperature == 0.)
         temperature = Temperature();
 
+      // Default pressure use internal value.
+      if(pressure == 0.)
+        pressure = Pressure();
+
       // read in from fcl parameter
 
-      double vd = fDriftVelocity; // cm/us.  For now just take it out of a fcl parameter.  Calcualted with magboltz and it's a strong function of gas composition
+      double vd = fDriftVelocity; // cm/us.  For now just take it out of a fcl parameter.  Calculated with Magboltz and it's a strong function of gas composition
 
       if(cmPerns) return vd * 1.e-3; // cm/ns
 
@@ -365,7 +383,8 @@ namespace gar {
       double samplingRate   = SamplingRate();
       double efield         = Efield();
       double temperature    = Temperature();
-      double driftVelocity  = DriftVelocity(efield, temperature);
+      double pressure       = Pressure();
+      double driftVelocity  = DriftVelocity(efield, temperature, pressure);
 
       fXTicksCoefficient    = 0.001 * driftVelocity * samplingRate;
 

--- a/DetectorInfo/DetectorPropertiesStandard.h
+++ b/DetectorInfo/DetectorPropertiesStandard.h
@@ -58,6 +58,10 @@ namespace gar {
           Name   ("Temperature"),
           Comment("argon temperature [K]")
         };
+        fhicl::Atom<double> Pressure{
+          Name   ("Pressure"),
+          Comment("argon pressure [bar]")
+        };
         fhicl::Atom<double> DriftVelocity{
           Name   ("DriftVelocity"),
           Comment("electron drift velocity in cm/us")
@@ -174,6 +178,7 @@ namespace gar {
 
       virtual double DriftVelocity(double efield=0.,
                                    double temperature=0.,
+				   double pressure=0.,
                                    bool   cmPerns=true) const override;  ///< cm/ns if true, otherwise cm/us
 
       /// dQ/dX in electrons/cm, returns dE/dX in MeV/cm.
@@ -181,8 +186,9 @@ namespace gar {
       virtual double ElectronLifetime()      const override { return fElectronlifetime;     }   //< microseconds
 
       /**
-       * @brief Returns argon density at a given temperature
+       * @brief Returns argon density at a given temperature and pressure.
        * @param temperature the temperature in kelvin
+       * @param pressure is the pressure in bar
        * @return argon density in g/cm^3
        *
        * Density is nearly a linear function of temperature.
@@ -190,13 +196,15 @@ namespace gar {
        * Slope is between -6.2 and -6.1, intercept is 1928 kg/m^3.
        * This parameterization will be good to better than 0.5%.
        */
-      virtual double Density(double temperature) const override;                          ///< g/cm^3
+      virtual double Density(double temperature, double pressure) const override;                          ///< g/cm^3
 
         // need to provide a definition, since the override above hides the inherited one
-      virtual double Density() const override { return Density(Temperature()); }
+      virtual double Density() const override { return Density(Temperature(),Pressure()); }
 
         /// In kelvin.
       virtual double Temperature()                   const override { return fTemperature; }
+        /// In bar.
+      virtual double Pressure()                      const override { return fPressure; }
 
       /**
        * @brief Restricted mean energy loss (dE/dx)
@@ -274,6 +282,7 @@ namespace gar {
       std::vector< double >          fEfield;                ///< kV/cm (per inter-plane volume)
       double                         fElectronlifetime;      ///< microseconds
       double                         fTemperature;           ///< kelvin
+      double                         fPressure;              ///< bar
       double                         fDriftVelocity;         ///< centimeters / microsecond
       double                         fSamplingRate;          ///< in ns
       double 	                       fElectronsToADC;        ///< conversion factor for # of ionization electrons to 1 ADC count

--- a/DetectorInfo/DetectorPropertiesStandardToad.cxx
+++ b/DetectorInfo/DetectorPropertiesStandardToad.cxx
@@ -1,6 +1,6 @@
 ////////////////////////////////////////////////////////////////////////
 //
-//  \file DetectorProperties.cxx
+//  \file DetectorPropertiesStandardToad.cxx
 //
 // Separation of service from Detector info class:
 // jpaley@fnal.gov
@@ -124,6 +124,7 @@ namespace gar {
       fEfield                     = config.Efield();
       fElectronlifetime           = config.Electronlifetime();
       fTemperature                = config.Temperature();
+      fPressure                   = config.Pressure();
       fDriftVelocity              = config.DriftVelocity();
       fElectronsToADC             = config.ElectronsToADC();
       fNumberTimeSamples          = config.NumberTimeSamples();
@@ -186,13 +187,21 @@ namespace gar {
 
 
       //------------------------------------------------
-    double DetectorPropertiesStandardToad::Density(double temperature) const
+    double DetectorPropertiesStandardToad::Density(double temperature, double pressure) const
     {
+      // Temperature in K, Pressure in bar
+      // density is in grams per cubic centimeter
+      
       // Default temperature use internal value.
       if(temperature == 0.)
         temperature = Temperature();
 
-      double density = -0.00615*temperature + 1.928;
+      if(pressure == 0.)
+	pressure = Pressure();
+
+      // linear expansion around 294 K, 10 bar
+      
+      double density = 0.01645 + 0.00167678*(pressure - 10.0) - 0.00005828*(temperature - 294.0);
 
       return density;
     } // DetectorPropertiesStandardToad::Density()
@@ -290,13 +299,15 @@ namespace gar {
 
     //------------------------------------------------------------------------------------//
     double DetectorPropertiesStandardToad::DriftVelocity(double efield,
-                                                     double temperature,
-                                                     bool   cmPerns) const
+                                                         double temperature,
+						         double pressure,
+                                                         bool   cmPerns) const
     {
 
       // Efield should have units of kV/cm
       // Temperature should have units of Kelvin
-
+      // Pressure should have units of bar
+      
       // Default Efield, use internal value.
       if(efield == 0.)
         efield = Efield();
@@ -314,9 +325,12 @@ namespace gar {
       if(temperature == 0.)
         temperature = Temperature();
 
+      if(pressure == 0.)
+	pressure = Pressure();
+      
       // read in from fcl parameter
 
-      double vd = fDriftVelocity; // cm/us.  For now just take it out of a fcl parameter.  Calcualted with magboltz and it's a strong function of gas composition
+      double vd = fDriftVelocity; // cm/us.  For now just take it out of a fcl parameter.  Calculated with Magboltz and it's a strong function of gas composition
 
       if(cmPerns) return vd * 1.e-3; // cm/ns
 
@@ -365,7 +379,8 @@ namespace gar {
       double samplingRate   = SamplingRate();
       double efield         = Efield();
       double temperature    = Temperature();
-      double driftVelocity  = DriftVelocity(efield, temperature);
+      double pressure       = Pressure();
+      double driftVelocity  = DriftVelocity(efield, temperature, pressure);
 
       fXTicksCoefficient    = 0.001 * driftVelocity * samplingRate;
 

--- a/DetectorInfo/DetectorPropertiesStandardToad.h
+++ b/DetectorInfo/DetectorPropertiesStandardToad.h
@@ -58,6 +58,10 @@ namespace gar {
           Name   ("Temperature"),
           Comment("argon temperature [K]")
         };
+        fhicl::Atom<double> Pressure{
+          Name   ("Pressure"),
+          Comment("argon pressure [bar]")
+        };
         fhicl::Atom<double> DriftVelocity{
           Name   ("DriftVelocity"),
           Comment("electron drift velocity in cm/us")
@@ -174,6 +178,7 @@ namespace gar {
 
       virtual double DriftVelocity(double efield=0.,
                                    double temperature=0.,
+				   double pressure=0.,
                                    bool   cmPerns=true) const override;  ///< cm/ns if true, otherwise cm/us
 
       /// dQ/dX in electrons/cm, returns dE/dX in MeV/cm.
@@ -181,8 +186,9 @@ namespace gar {
       virtual double ElectronLifetime()      const override { return fElectronlifetime;     }   //< microseconds
 
       /**
-       * @brief Returns argon density at a given temperature
+       * @brief Returns argon density at a given temperature and pressure
        * @param temperature the temperature in kelvin
+       * @param pressure the pressure in bar
        * @return argon density in g/cm^3
        *
        * Density is nearly a linear function of temperature.
@@ -190,13 +196,16 @@ namespace gar {
        * Slope is between -6.2 and -6.1, intercept is 1928 kg/m^3.
        * This parameterization will be good to better than 0.5%.
        */
-      virtual double Density(double temperature) const override;                          ///< g/cm^3
+      virtual double Density(double temperature, double pressure) const override;                          ///< g/cm^3
 
         // need to provide a definition, since the override above hides the inherited one
-      virtual double Density() const override { return Density(Temperature()); }
+      virtual double Density() const override { return Density(Temperature(), Pressure()); }
 
         /// In kelvin.
       virtual double Temperature()                   const override { return fTemperature; }
+
+        /// In bar.
+      virtual double Pressure()                      const override { return fPressure; }
 
       /**
        * @brief Restricted mean energy loss (dE/dx)
@@ -283,6 +292,7 @@ namespace gar {
       std::vector< double >          fEfield;                ///< kV/cm (per inter-plane volume)
       double                         fElectronlifetime;      ///< microseconds
       double                         fTemperature;           ///< kelvin
+      double                         fPressure;              ///< bar
       double                         fDriftVelocity;         ///< centimeters / microsecond
       double                         fSamplingRate;          ///< in ns
       double 	                       fElectronsToADC;        ///< conversion factor for # of ionization electrons to 1 ADC count

--- a/DetectorInfo/DetectorProperties_toad.fcl
+++ b/DetectorInfo/DetectorProperties_toad.fcl
@@ -6,6 +6,7 @@ standard_detproperties:
 
  # Drift properties
  Temperature:           294.26          # Kelvin  (70F)
+ Pressure:              10.0            # bar
  Efield:                [0.5,0.5,0.5 ]  # kV/cm -- three wire planes in larsoft -- fix for ALICE anode
  Electronlifetime:      3e6             # microseconds
  DriftVelocity:         3.011           # in cm/us


### PR DESCRIPTION
add pressure to detector info, standard and TOAD, and add it to a linear expansion of density(T,P)

addresses https://github.com/DUNE/garsoft/issues/14

To make better -- density should be more inversely proportional to T.  It is a linear expansion around 10 bar, 294 K, based on numerical tables in Gosman, McCarty, and Hust, "Thermodynamic Properties of Argon From the Triple Point to 300 K at Pressures to 1000 Atmospheres", NSRDS-NBS 27 (1969).  One could parameterize more carefully if we want to go to very different temperatures.  Pressure dependence should be approximately linear (but not quite -- I wouldn't trust this at 100 bar for example).