### PR TITLE
add a variation on the ALICE pad position class for square pixels

### DIFF
--- a/Geometry/ChannelMapAlgs/AliTPCROCSquare.cxx
+++ b/Geometry/ChannelMapAlgs/AliTPCROCSquare.cxx
@@ -1,0 +1,478 @@
+/**************************************************************************
+ * Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
+ *                                                                        *
+ * Author: The ALICE Off-line Project.                                    *
+ * Contributors are mentioned in the code where appropriate.              *
+ *                                                                        *
+ * Permission to use, copy, modify and distribute this software and its   *
+ * documentation strictly for non-commercial purposes is hereby granted   *
+ * without fee, provided that the above copyright notice appears in all   *
+ * copies and that both the copyright notice and this permission notice   *
+ * appear in the supporting documentation. The authors make no claims     *
+ * about the suitability of this software for any purpose. It is          *
+ * provided "as is" without express or implied warranty.                  *
+ **************************************************************************/
+
+/* modified from ALICE's AliTPCROC to make for more square pads by        *
+ * T. Junk, September 2024  */
+
+/// \class AliTPCROCSquare
+/// \brief Geometry class for a single ROC
+
+#include "Geometry/ChannelMapAlgs/AliTPCROCSquare.h"
+#include "TMath.h"
+
+/// \cond CLASSIMP
+//ClassImp(AliTPCROCSquare)
+/// \endcond
+
+
+AliTPCROCSquare* AliTPCROCSquare::fgInstance = 0;
+
+
+
+
+//_ singleton implementation __________________________________________________
+AliTPCROCSquare* AliTPCROCSquare::Instance()
+{
+  /// Singleton implementation
+  /// Returns an instance of this class, it is created if neccessary
+
+  if (fgInstance == 0){
+    fgInstance = new AliTPCROCSquare();
+    fgInstance->Init();
+  }
+  return fgInstance;
+}
+
+
+
+
+void AliTPCROCSquare::Init(){
+  /// initialize static variables
+
+  if (AliTPCROCSquare::fNSectorsAll>0) return;
+  fNSectorsAll =72;
+  fNSectors[0] =36;
+  fNSectors[1] =36;
+  //
+  fNRows[0]= 63*1.26;
+  fNRows[1]= 96*3.5;
+  //
+  // number of pads in padrow
+  fNPads[0] = new UInt_t[fNRows[0]];
+  fNPads[1] = new UInt_t[fNRows[1]];
+  //
+  // padrow index in array
+  //
+  fRowPosIndex[0] = new UInt_t[fNRows[0]];
+  fRowPosIndex[1] = new UInt_t[fNRows[1]];
+  //
+  // inner sectors
+  //
+  UInt_t index =0;
+  for (UInt_t irow=0; irow<fNRows[0];irow++){
+    UInt_t npads = (irow==0) ? 47 : 2 *Int_t(Double_t(irow)/(3.*1.9) +33.67/1.4);
+    fNPads[0][irow] = npads;
+    fRowPosIndex[0][irow] = index;
+    index+=npads;
+  }
+  fNChannels[0] = index;
+  //
+  index =0;
+  Double_t k1 = 6.*TMath::Tan(10*TMath::DegToRad())/6.;
+  //Double_t k2 = 6.*TMath::Tan(10*TMath::DegToRad())/6.;
+  for (UInt_t irow=0; irow<fNRows[1];irow++){
+    UInt_t npads = 2*Int_t(k1*Double_t(irow)+37.75);
+    fNPads[1][irow] = npads;
+    fRowPosIndex[1][irow] = index;
+    index+=npads;
+  }
+  fNChannels[1] = index;
+  SetGeometry();
+}
+
+
+
+
+void AliTPCROCSquare::SetGeometry()
+{
+  /// set ROC geometry parameters
+
+  const  Float_t kInnerRadiusLow = 83.65;
+  const  Float_t kInnerRadiusUp  = 133.3;
+  const  Float_t kOuterRadiusLow = 133.5;
+  const  Float_t kOuterRadiusUp  = 247.7;
+  const  Float_t kInnerFrameSpace = 1.5;
+  const  Float_t kOuterFrameSpace = 1.5;
+  const  Float_t kInnerWireMount = 1.2;
+  const  Float_t kOuterWireMount = 1.4;
+  const  Float_t kZLength =250.;  // need to adjust this in DUNE MPD.
+  const  UInt_t   kNRowLow = 63 * 1.25;
+  const  UInt_t   kNRowUp1 = 64 * 2.1;
+  const  UInt_t   kNRowUp2 = 32 * 1.7;
+  const  UInt_t   kNRowUp  = kNRowUp1+kNRowUp2;
+  const  Float_t kInnerAngle = 20; // 20 degrees
+  const  Float_t kOuterAngle = 20; // 20 degrees
+  //
+  //  pad     parameters
+  //
+  const Float_t  kInnerPadPitchLength = 0.6;
+  const Float_t  kInnerPadPitchWidth = 0.6;
+  const Float_t  kInnerPadLength = 0.6;
+  const Float_t  kInnerPadWidth = 0.6;
+  const Float_t  kOuter1PadPitchLength = 0.6;
+  const Float_t  kOuterPadPitchWidth = 0.6;
+  const Float_t  kOuter1PadLength = 0.6;
+  const Float_t  kOuterPadWidth = 0.6;
+  const Float_t  kOuter2PadPitchLength = 0.6;
+  const Float_t  kOuter2PadLength = 0.6;
+
+  //
+  //wires default parameters
+  //
+  //   const UInt_t    kNInnerWiresPerPad = 3;
+  //   const UInt_t    kInnerDummyWire = 2;
+  //   const Float_t  kInnerWWPitch = 0.25;
+  //   const Float_t  kRInnerFirstWire = 84.475;
+  //   const Float_t  kRInnerLastWire = 132.475;
+  //   const Float_t  kInnerOffWire = 0.5;
+  //   const UInt_t    kNOuter1WiresPerPad = 4;
+  //   const UInt_t    kNOuter2WiresPerPad = 6;
+  //   const Float_t  kOuterWWPitch = 0.25;
+  //   const Float_t  kROuterFirstWire = 134.225;
+  //   const Float_t  kROuterLastWire = 246.975;
+  //   const UInt_t    kOuterDummyWire = 2;
+  //   const Float_t  kOuterOffWire = 0.5;
+  //
+  //set sector parameters
+  //
+  fInnerRadiusLow = kInnerRadiusLow;
+  fOuterRadiusLow = kOuterRadiusLow;
+  fInnerRadiusUp  = kInnerRadiusUp;
+  fOuterRadiusUp  = kOuterRadiusUp;
+  fInnerFrameSpace = kInnerFrameSpace;
+  fOuterFrameSpace = kOuterFrameSpace;
+  fInnerWireMount  = kInnerWireMount;
+  fOuterWireMount  = kOuterWireMount;
+  fZLength         = kZLength;
+  fInnerAngle      =  TMath::DegToRad()*kInnerAngle;
+  fOuterAngle      =  TMath::DegToRad()*kOuterAngle;
+
+  fNRowLow       = kNRowLow;
+  fNRowUp1      = kNRowUp1;
+  fNRowUp2       = kNRowUp2;
+  fNRowUp        = kNRowUp;
+  //
+  //set pad parameter
+  //
+  fInnerPadPitchLength = kInnerPadPitchLength;
+  fInnerPadPitchWidth  = kInnerPadPitchWidth;
+  fInnerPadLength      = kInnerPadLength;
+  fInnerPadWidth       = kInnerPadWidth;
+  fOuter1PadPitchLength = kOuter1PadPitchLength;
+  fOuter2PadPitchLength = kOuter2PadPitchLength;
+  fOuterPadPitchWidth   = kOuterPadPitchWidth;
+  fOuter1PadLength      = kOuter1PadLength;
+  fOuter2PadLength      = kOuter2PadLength;
+  fOuterPadWidth        = kOuterPadWidth;
+
+  //
+  //set wire parameters
+  //
+  // SetInnerNWires(kNInnerWiresPerPad);
+  //   SetInnerDummyWire(kInnerDummyWire);
+  //   SetInnerOffWire(kInnerOffWire);
+  //   SetOuter1NWires(kNOuter1WiresPerPad);
+  //   SetOuter2NWire(kNOuter2WiresPerPad);
+  //   SetOuterDummyWire(kOuterDummyWire);
+  //   SetOuterOffWire(kOuterOffWire);
+  //   SetInnerWWPitch(kInnerWWPitch);
+  //   SetRInnerFirstWire(kRInnerFirstWire);
+  //   SetRInnerLastWire(kRInnerLastWire);
+  //   SetOuterWWPitch(kOuterWWPitch);
+  //   SetROuterFirstWire(kROuterFirstWire);
+  //   SetROuterLastWire(kROuterLastWire);
+
+  UInt_t i=0;
+  Float_t firstrow = fInnerRadiusLow + 1.575;
+  for( i= 0;i<fNRowLow;i++)
+    {
+      Float_t x = firstrow + fInnerPadPitchLength*(Float_t)i;
+      fPadRowLow[i]=x;
+      fYInner[i+1]  = x*TMath::Tan(fInnerAngle/2.)-fInnerWireMount;
+      fNPadsLow[i] = GetNPads(0,i) ;     // ROC implement
+    }
+  // cross talk rows
+  fYInner[0]=(fPadRowLow[0]-fInnerPadPitchLength)*TMath::Tan(fInnerAngle/2.)-fInnerWireMount;
+  fYInner[fNRowLow+1]=(fPadRowLow[fNRowLow-1]+fInnerPadPitchLength)*TMath::Tan(fInnerAngle/2.)-fInnerWireMount;
+  firstrow = fOuterRadiusLow + 1.6;
+  for(i=0;i<fNRowUp;i++)
+    {
+      if(i<fNRowUp1){
+	Float_t x = firstrow + fOuter1PadPitchLength*(Float_t)i;
+	fPadRowUp[i]=x;
+	fYOuter[i+1]= x*TMath::Tan(fOuterAngle/2.)-fOuterWireMount;
+	fNPadsUp[i] =  GetNPads(36,i) ;     // ROC implement
+	if(i==fNRowUp1-1) {
+	  fLastWireUp1=fPadRowUp[i] +0.625;
+	  firstrow = fPadRowUp[i] + 0.5*(fOuter1PadPitchLength+fOuter2PadPitchLength) + 0.3;
+	}
+      }
+      else
+      	{
+	  Float_t x = firstrow + fOuter2PadPitchLength*(Float_t)(i-64*2.1);
+	  fPadRowUp[i]=x;
+	  fNPadsUp[i] =  GetNPads(36,i) ;     // ROC implement
+      	}
+      fYOuter[i+1]  = fPadRowUp[i]*TMath::Tan(fOuterAngle/2.)-fOuterWireMount;
+    }
+
+
+
+}
+
+
+
+
+//_____________________________________________________________________________
+AliTPCROCSquare::AliTPCROCSquare()
+  :TObject(),
+   fNSectorsAll(0),
+   fInnerRadiusLow(0.),
+   fInnerRadiusUp(0.),
+   fOuterRadiusUp(0.),
+   fOuterRadiusLow(0.),
+   fInnerFrameSpace(0.),
+   fOuterFrameSpace(0.),
+   fInnerWireMount(0.),
+   fOuterWireMount(0.),
+   fZLength(0.),
+   fInnerAngle(0.),
+   fOuterAngle(0.),
+   fNInnerWiresPerPad(0),
+   fInnerWWPitch(0.),
+   fInnerDummyWire(0),
+   fInnerOffWire(0.),
+   fRInnerFirstWire(0.),
+   fRInnerLastWire(0.),
+   fLastWireUp1(0.),
+   fNOuter1WiresPerPad(0),
+   fNOuter2WiresPerPad(0),
+   fOuterWWPitch(0.),
+   fOuterDummyWire(0),
+   fOuterOffWire(0),
+   fROuterFirstWire(0.),
+   fROuterLastWire(0),
+   fInnerPadPitchLength(0.),
+   fInnerPadPitchWidth(0.),
+   fInnerPadLength(0.),
+   fInnerPadWidth(0.),
+   fOuter1PadPitchLength(0.),
+   fOuter2PadPitchLength(0),
+   fOuterPadPitchWidth(0),
+   fOuter1PadLength(0.),
+   fOuter2PadLength(0),
+   fOuterPadWidth(0),
+   fNRowLow(0),
+   fNRowUp1(0),
+   fNRowUp2(0),
+   fNRowUp(0),
+   fNtRows(0)
+{
+  /// Default constructor
+
+  for (UInt_t i=0;i<2;i++){
+    fNSectors[i]  = 0;
+    fNRows[i]     = 0;
+    fNChannels[i] = 0;
+    fNPads[i]     = 0;
+    fRowPosIndex[i]= 0;
+  }
+
+  for (UInt_t i=0;i<400;++i){
+    fPadRowLow[i]=0.;
+    fPadRowUp[i]=0.;
+    fNPadsLow[i]=0;
+    fNPadsUp[i]=0;
+    fYInner[i]=0.;
+    fYOuter[i]=0.;
+  }
+}
+
+
+//_____________________________________________________________________________
+AliTPCROCSquare::AliTPCROCSquare(const AliTPCROCSquare &roc)
+  :TObject(roc),
+   fNSectorsAll(0),
+   fInnerRadiusLow(0.),
+   fInnerRadiusUp(0.),
+   fOuterRadiusUp(0.),
+   fOuterRadiusLow(0.),
+   fInnerFrameSpace(0.),
+   fOuterFrameSpace(0.),
+   fInnerWireMount(0.),
+   fOuterWireMount(0.),
+   fZLength(0.),
+   fInnerAngle(0.),
+   fOuterAngle(0.),
+   fNInnerWiresPerPad(0),
+   fInnerWWPitch(0.),
+   fInnerDummyWire(0),
+   fInnerOffWire(0.),
+   fRInnerFirstWire(0.),
+   fRInnerLastWire(0.),
+   fLastWireUp1(0.),
+   fNOuter1WiresPerPad(0),
+   fNOuter2WiresPerPad(0),
+   fOuterWWPitch(0.),
+   fOuterDummyWire(0),
+   fOuterOffWire(0),
+   fROuterFirstWire(0.),
+   fROuterLastWire(0),
+   fInnerPadPitchLength(0.),
+   fInnerPadPitchWidth(0.),
+   fInnerPadLength(0.),
+   fInnerPadWidth(0.),
+   fOuter1PadPitchLength(0.),
+   fOuter2PadPitchLength(0),
+   fOuterPadPitchWidth(0),
+   fOuter1PadLength(0.),
+   fOuter2PadLength(0),
+   fOuterPadWidth(0),
+   fNRowLow(0),
+   fNRowUp1(0),
+   fNRowUp2(0),
+   fNRowUp(0),
+   fNtRows(0)
+
+{
+  /// AliTPCROCSquare copy constructor
+
+  fNSectorsAll = roc.fNSectorsAll;
+  fNSectors[0] = roc.fNSectors[0];
+  fNSectors[1] = roc.fNSectors[1];
+  fNRows[0]    = roc.fNRows[0];
+  fNRows[1]    = roc.fNRows[1];
+  fNChannels[0]= roc.fNChannels[0];
+  fNChannels[1]= roc.fNChannels[1];
+  //
+  // number of pads in padrow
+  fNPads[0] = new UInt_t[fNRows[0]];
+  fNPads[1] = new UInt_t[fNRows[1]];
+  //
+  // padrow index in array
+  //
+  fRowPosIndex[0] = new UInt_t[fNRows[0]];
+  fRowPosIndex[1] = new UInt_t[fNRows[1]];
+  //
+  for (UInt_t irow =0; irow<fNRows[0];irow++){
+    fNPads[0][irow]       = roc.fNPads[0][irow];
+    fRowPosIndex[0][irow] = roc.fRowPosIndex[0][irow];
+  }
+  for (UInt_t irow =0; irow<fNRows[1];irow++){
+    fNPads[1][irow]       = roc.fNPads[1][irow];
+    fRowPosIndex[1][irow] = roc.fRowPosIndex[1][irow];
+  }
+
+  for (UInt_t i=0;i<400;++i){
+    fPadRowLow[i]=roc.fPadRowLow[i];
+    fPadRowUp[i]=roc.fPadRowUp[i];
+    fNPadsLow[i]=roc.fNPadsLow[i];
+    fNPadsUp[i]=roc.fNPadsUp[i];
+    fYInner[i]=roc.fYInner[i];
+    fYOuter[i]=roc.fYOuter[i];
+  }
+
+}
+//____________________________________________________________________________
+AliTPCROCSquare & AliTPCROCSquare::operator =(const AliTPCROCSquare & roc)
+{
+  /// assignment operator - dummy
+
+  if (this == &roc) return (*this);
+
+  fZLength = roc.fZLength;
+  return (*this);
+}
+//_____________________________________________________________________________
+AliTPCROCSquare::~AliTPCROCSquare()
+{
+  /// AliTPCROCSquare destructor
+
+  delete [] fNPads[0];
+  delete [] fNPads[1];
+  delete [] fRowPosIndex[0];
+  delete [] fRowPosIndex[1];
+  fgInstance = 0x0;
+
+}
+
+
+
+
+void AliTPCROCSquare::GetPositionLocal(UInt_t sector, UInt_t row, UInt_t pad, Float_t *pos){
+  /// get position of center of pad - ideal frame used
+
+  pos[2]=fZLength;
+  if (sector<36){
+    pos[0] = fPadRowLow[row];
+    pos[1] = fInnerPadPitchWidth*(Int_t(pad)+0.5-Int_t(fNPads[0][row])/2);
+  }else{
+    pos[0] = fPadRowUp[row];
+    pos[1] = fOuterPadPitchWidth*(Int_t(pad)+0.5-Int_t(fNPads[1][row])/2);
+  }
+  if ((sector%36)>=18){
+    pos[2] *= -1.;
+    pos[1] *= -1.;
+  }
+}
+
+
+void AliTPCROCSquare::GetPositionGlobal(UInt_t sector, UInt_t row, UInt_t pad, Float_t *pos){
+  /// get position of center of pad - ideal frame used
+
+  GetPositionLocal(sector,row,pad,pos);
+  Double_t alpha = TMath::DegToRad()*(10.+20.*(sector%18));
+  Float_t gx = pos[0]*TMath::Cos(alpha)-pos[1]*TMath::Sin(alpha);
+  Float_t gy = pos[1]*TMath::Cos(alpha)+pos[0]*TMath::Sin(alpha);
+  pos[0] = gx;
+  pos[1] = gy;
+}
+
+
+Float_t AliTPCROCSquare::GetIdealPosition(UInt_t sector, UInt_t row, UInt_t pad,  coordType coord){
+  //
+  // return ideal position accoring hardwired geometry in the class
+  //
+
+  AliTPCROCSquare *roc = AliTPCROCSquare::Instance();
+  Float_t pos[3];
+  if (coord==kLx){
+    roc->GetPositionLocal(sector, row,pad,pos);
+    return pos[0];
+  }
+  if (coord==kLy){
+    roc->GetPositionLocal(sector, row,pad,pos);
+    return pos[1];
+  }
+  if (coord==kLz){
+    roc->GetPositionLocal(sector, row,pad,pos);
+    return pos[2];
+  }
+  if (coord==kGx){
+    roc->GetPositionGlobal(sector, row,pad,pos);
+    return pos[0];
+  }
+  if (coord==kGy){
+    roc->GetPositionGlobal(sector, row,pad,pos);
+    return pos[1];
+  }
+  if (coord==kGz){
+    roc->GetPositionGlobal(sector, row,pad,pos);
+    return pos[2];
+  }
+
+  return 0;
+
+}

--- a/Geometry/ChannelMapAlgs/AliTPCROCSquare.h
+++ b/Geometry/ChannelMapAlgs/AliTPCROCSquare.h
@@ -1,25 +1,26 @@
-#ifndef ALITPCROC_H
-#define ALITPCROC_H
+#ifndef ALITPCROCSQUARE_H
+#define ALITPCROCSQUARE_H
 /* Copyright(c) 1998-1999, ALICE Experiment at CERN, All rights reserved. *
  * See cxx source for full Copyright notice                               */
+/* Modified to have square-ish pads instea of ALICE-sytle long pads */
 
-/* $Id: AliTPCROC.h,v */
+/* $Id: AliTPCROCSquare.h,v */
 
-/// \class AliTPCROC
+/// \class AliTPCROCSquare
 /// \brief TPC geometry class for ROC
 
 #include <TObject.h>
 
 //_____________________________________________________________________________
-class AliTPCROC : public TObject {
+class AliTPCROCSquare : public TObject {
  public: 
   enum coordType{ kLx=0, kLy=1, kLz=2, kGx=3, kGy=4, kGz=5};
-  static AliTPCROC* Instance();
-  AliTPCROC();
-  AliTPCROC(const AliTPCROC &roc);
-  AliTPCROC &operator = (const AliTPCROC & roc); //assignment operator
+  static AliTPCROCSquare* Instance();
+  AliTPCROCSquare();
+  AliTPCROCSquare(const AliTPCROCSquare &roc);
+  AliTPCROCSquare &operator = (const AliTPCROCSquare & roc); //assignment operator
   void Init();
-  virtual           ~AliTPCROC();
+  virtual           ~AliTPCROCSquare();
   void GetPositionLocal(UInt_t sector, UInt_t row, UInt_t pad, Float_t *pos);
   void GetPositionGlobal(UInt_t sector, UInt_t row, UInt_t pad, Float_t *pos);
   //
@@ -56,7 +57,7 @@ class AliTPCROC : public TObject {
   Float_t  GetOuterPadWidth() const {return fOuterPadWidth; }
   Float_t  GetOuter1PadLength() const {return fOuter1PadLength; }
   Float_t  GetOuter2PadLength() const {return fOuter2PadLength; }
-  Float_t  GetOROCPadHeightChangeRadius() const {return 198.6; }  // trj add so we can generalize a bit
+  Float_t  GetOROCPadHeightChangeRadius() const {return 100000.0; }  // pad height never changes
   //
   // get pad row parameters
   //
@@ -131,16 +132,16 @@ protected:
   UInt_t     fNRowUp2;            ///< number of long pad rows per sector up   -set
   UInt_t     fNRowUp;            ///< number of pad rows per sector up     -calculated
   UInt_t     fNtRows;            ///< total number of rows in TPC          -calculated
-  Float_t   fPadRowLow[100]; ///< Lower sector, pad row radii          -calculated
-  Float_t   fPadRowUp[100];  ///< Upper sector, pad row radii          -calculated
-  UInt_t     fNPadsLow[100];  ///< Lower sector, number of pads per row -calculated
-  UInt_t     fNPadsUp[100];   ///< Upper sector, number of pads per row -calculated
-  Float_t   fYInner[100];     ///< Inner sector, wire-length
-  Float_t   fYOuter[100];     ///< Outer sector, wire-length
+  Float_t   fPadRowLow[400]; ///< Lower sector, pad row radii          -calculated
+  Float_t   fPadRowUp[400];  ///< Upper sector, pad row radii          -calculated
+  UInt_t     fNPadsLow[400];  ///< Lower sector, number of pads per row -calculated
+  UInt_t     fNPadsUp[400];   ///< Upper sector, number of pads per row -calculated
+  Float_t   fYInner[400];     ///< Inner sector, wire-length
+  Float_t   fYOuter[400];     ///< Outer sector, wire-length
  protected:
-  static AliTPCROC*   fgInstance; //!<! Instance of this class (singleton implementation)
+  static AliTPCROCSquare*   fgInstance; //!<! Instance of this class (singleton implementation)
   /// \cond CLASSIMP
-  //  ClassDef(AliTPCROC,0)    //  TPC ROC class
+  //  ClassDef(AliTPCROCSquare,0)    //  TPC ROC class
   /// \endcond
 };
 

--- a/Geometry/ChannelMapAlgs/ChannelMapStandardAlg.cxx
+++ b/Geometry/ChannelMapAlgs/ChannelMapStandardAlg.cxx
@@ -28,7 +28,7 @@ namespace gar {
 
 		fGeo = &geo;
 
-                fROC = AliTPCROC::Instance();
+                fROC = AliTPCROCSquare::Instance();
 
                 //std::string driftvolname = geo.GetGArTPCVolumeName();
 
@@ -56,7 +56,7 @@ namespace gar {
                 fIROCInnerRadius = fROC->GetInnerRadiusLow() + 1.575;
                 fIROCOuterRadius = fROC->GetInnerRadiusUp();
                 fOROCInnerRadius = fROC->GetOuterRadiusLow()+1.6;
-                fOROCPadHeightChangeRadius = 198.6;
+                fOROCPadHeightChangeRadius = fROC->GetOROCPadHeightChangeRadius();
                 fOROCOuterRadius = fROC->GetOuterRadiusUp();
 
                 // old hardcoded numbers
@@ -96,6 +96,10 @@ namespace gar {
                             pos[2] = pos[0];
                             pos[0] = -fXPlaneLoc;
                             fPixelCenters.emplace_back(pos[0]+fTPCCenter.x,pos[1]+fTPCCenter.y,pos[2]+fTPCCenter.z);
+			    if (std::abs(pos[2])>1E6 || std::abs(pos[1]>1E6))
+			      {
+				std::cout << "IROC bad pixel loc: " << pos[1] << " " << pos[2] << " " << irow << " " << ipad << " " << numpads << std::endl;
+			      }
                             ipadacc++;
                         }
                     }
@@ -118,6 +122,10 @@ namespace gar {
                             pos[2] = pos[0];
                             pos[0] = -fXPlaneLoc;
                             fPixelCenters.emplace_back(pos[0]+fTPCCenter.x,pos[1]+fTPCCenter.y,pos[2]+fTPCCenter.z);
+			    if (std::abs(pos[2])>1E6 || std::abs(pos[1]>1E6))
+			      {
+				std::cout << "OROC bad pixel loc: " << pos[1] << " " << pos[2] << " " << irow << " " << ipad << " " << numpads << std::endl;
+			      }
                             ipadacc++;
                         }
                         if (isector == 0) fNumChansPerSector = ipadacc;
@@ -141,6 +149,10 @@ namespace gar {
                         zloc = ( (float) ipad - (float) numpads/2 + 0.5 )*fCenterPadWidth;
                         XYZPos pixpos(-fXPlaneLoc+fTPCCenter.x,yloc+fTPCCenter.y,zloc+fTPCCenter.z);
                         fPixelCenters.push_back(pixpos);
+			if (std::abs(pixpos.z)>1E6 || std::abs(pixpos.y>1E6))
+			      {
+				std::cout << "CROC bad pixel loc: " << pixpos.y << " " << pixpos.z << " " << irow << " " << ipad << " " << numpads << std::endl;
+			      }
                         fNumChansCenter++;
                     }
                 }
@@ -229,7 +241,7 @@ namespace gar {
             }
 
             //----------------------------------------------------------------------------
-            // wrapper for backward compatibility -- versiont that does not return the roctype.
+            // wrapper for backward compatibility -- version that does not return the roctype.
 
             unsigned int ChannelMapStandardAlg::NearestChannel(float const* xyz) const
             {

--- a/Geometry/ChannelMapAlgs/ChannelMapStandardAlg.h
+++ b/Geometry/ChannelMapAlgs/ChannelMapStandardAlg.h
@@ -14,7 +14,7 @@
 
 #include "Geometry/ChannelMapAlgs/ChannelMapAlg.h"
 #include "fhiclcpp/ParameterSet.h"
-#include "Geometry/ChannelMapAlgs/AliTPCROC.h"
+#include "Geometry/ChannelMapAlgs/AliTPCROCSquare.h"
 #include "Geometry/GeometryGAr.h"
 #include "CoreUtils/ServiceUtil.h"
 
@@ -65,7 +65,7 @@ namespace gar{
 
                 void NearestChannelWithROCType(float const *xyz, gar::geo::ROCType &roctype, unsigned int &nearestchannel) const;
 
-                AliTPCROC           *fROC;                       ///< TPC Readout geometry from ALICE software stack
+                AliTPCROCSquare     *fROC;                       ///< TPC Readout geometry from ALICE software stack
                 UInt_t              fNumSectors;                 ///<   Number of sectors -- should be 18
                 float               fSectorOffsetAngleDeg;       ///<   Angle to rotate to the middle of the first sector -- should be 10 degrees
                 float               fPhiSectorWidth;             ///<   width of a sector in phi (in radians)


### PR DESCRIPTION
On Patrick's request, I made a new version of the AliTPCROC class, called AliTPCROCSquare, with adjusted parameters for square pads, 6 mm on a side.  There are still IROC, OROC (just one kind of pad in the OROC now), and CROC.  Enclosed are plots of the pad locations, and an event with raw digits over threshold and reconstructed tracks.  There are now 508906 pads per side.  The geometry is still double-sided with a cathode in the middle.  This is easy enough to switch in the future, though the cathode-crossing track stitcher module should be taken out of the reco for that.
![squarepixelsrecoexample1](https://github.com/user-attachments/assets/08810025-5bbf-4889-960c-b1bcc02da2de)
![squarepixelsrawexample1](https://github.com/user-attachments/assets/d7fb5547-490e-46c6-80ed-12e08b81f789)
![squarepixels](https://github.com/user-attachments/assets/036f15b1-26c4-4000-b973-2ba0049c1b46)
